### PR TITLE
Add custom launcher icon for the MDM client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: "8.2"
+          gradle-version: "8.9"
 
       - name: Build debug APK
         working-directory: mdm-client

--- a/mdm-client/app/src/main/AndroidManifest.xml
+++ b/mdm-client/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <application
         android:name=".MdmClientApplication"
         android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">

--- a/mdm-client/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/mdm-client/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path android:pathData="M0,0h108v108h-108z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="0"
+                android:startY="0"
+                android:endX="108"
+                android:endY="108">
+                <item android:offset="0" android:color="#FF16344F" />
+                <item android:offset="1" android:color="#FF0A1726" />
+            </gradient>
+        </aapt:attr>
+    </path>
+
+</vector>

--- a/mdm-client/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/mdm-client/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Signal arcs radiating upward from the headset -->
+    <path
+        android:pathData="M47.64,45.64 A9,9 0 0 1 60.36,45.64 M42.69,40.69 A16,16 0 0 1 65.31,40.69 M37.74,35.74 A23,23 0 0 1 70.26,35.74"
+        android:strokeColor="#22D3EE"
+        android:strokeWidth="4.5"
+        android:strokeLineCap="round" />
+
+    <!-- HMD front silhouette with lens cutouts and nose notch -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M37,56 L71,56 A7,7 0 0 1 78,63 L78,71 A7,7 0 0 1 71,78 L60.5,78 A6.5,6.5 0 0 0 47.5,78 L37,78 A7,7 0 0 1 30,71 L30,63 A7,7 0 0 1 37,56 Z M42,61.5 A5.5,5.5 0 1 0 42,72.5 A5.5,5.5 0 1 0 42,61.5 Z M66,61.5 A5.5,5.5 0 1 0 66,72.5 A5.5,5.5 0 1 0 66,61.5 Z" />
+
+</vector>

--- a/mdm-client/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/mdm-client/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
## Summary

- Replace the default Android launcher icon with an original adaptive icon: a white HMD front silhouette with cyan signal arcs radiating upward, on a dark navy gradient background — visualizing "remote control of headsets"
- Implemented entirely as vector drawables (`ic_launcher_foreground.xml` / `ic_launcher_background.xml`), so no raster assets are needed and the icon stays sharp at any density
- Includes a `monochrome` layer for Android 13+ themed icons
- Adds the previously missing `android:icon` attribute to the manifest (the app fell back to the system default icon without it)
- Also fixes the release workflow: AGP 8.7.0 requires Gradle 8.9+, but `release.yml` pinned Gradle 8.2, which fails before configuration

## Verification

- `gradle assembleDebug` succeeds with Gradle 8.9 (and reproduces the CI failure on 8.2)
- `aapt2 dump badging` on the built APK confirms `application-icon-*` entries point to `res/mipmap-anydpi-v26/ic_launcher.xml` for all densities

🤖 Generated with [Claude Code](https://claude.com/claude-code)