### PR TITLE
Build signed release APK in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,24 @@ jobs:
         with:
           gradle-version: "8.9"
 
-      - name: Build debug APK
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > mdm-client/release.keystore
+
+      - name: Build release APK
         working-directory: mdm-client
-        run: gradle assembleDebug
+        env:
+          KEYSTORE_FILE: ${{ github.workspace }}/mdm-client/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: gradle assembleRelease
 
       - name: Upload APK to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          APK=$(find mdm-client/app/build/outputs/apk/debug -name "*.apk" | head -1)
-          gh release upload "${{ github.event.release.tag_name }}" "$APK" --clobber
+          APK=$(find mdm-client/app/build/outputs/apk/release -name "*.apk" | head -1)
+          gh release upload "$RELEASE_TAG" "$APK" --clobber

--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -15,10 +15,25 @@ android {
         versionName "1.0.0"
     }
 
+    signingConfigs {
+        release {
+            // Signing credentials are injected via environment variables in CI
+            if (System.getenv("KEYSTORE_FILE") != null) {
+                storeFile file(System.getenv("KEYSTORE_FILE"))
+                storePassword System.getenv("KEYSTORE_PASSWORD")
+                keyAlias System.getenv("KEY_ALIAS")
+                keyPassword System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (System.getenv("KEYSTORE_FILE") != null) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Switch the release workflow from `assembleDebug` to `assembleRelease` so GitHub Releases get a release APK instead of a debug one
- Sign the release APK with a keystore injected via GitHub Secrets (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`); local builds without these env vars still produce an unsigned APK as before
- Pass secrets and the release tag to `run:` steps via `env:` instead of direct `${{ }}` interpolation

## Required setup before the next release
Create a keystore and register the four secrets:

```bash
keytool -genkeypair -keystore release.keystore -alias styly-mdm \
  -keyalg RSA -keysize 2048 -validity 10000

gh secret set KEYSTORE_BASE64 < <(base64 -i release.keystore)
gh secret set KEYSTORE_PASSWORD
gh secret set KEY_ALIAS --body "styly-mdm"
gh secret set KEY_PASSWORD
```

Keep the keystore safe — changing the signing key prevents in-place updates of the MDM client.

## Test plan
- [x] Local `assembleRelease` without signing env vars produces `app-release-unsigned.apk`
- [x] Local `assembleRelease` with a test keystore produces a signed `app-release.apk`
- [ ] Create a GitHub release after registering the secrets and confirm the signed APK is attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)