### PR TITLE
Set app versionName to 0.1.0

### DIFF
--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 29
         targetSdk 33
         versionCode 1
-        versionName "1.0.0"
+        versionName "0.1.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
## Summary
- Change the MDM client app `versionName` from `1.0.0` to `0.1.0` in `mdm-client/app/build.gradle`

`versionCode` is left unchanged at `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)