### PR TITLE
Add in-app All Files Access permission flow to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Uploaded APKs are stored under `mdm-server/apks/` and served to devices over the
 > adb shell appops set com.styly.mdmclient MANAGE_EXTERNAL_STORAGE allow
 > ```
 >
-> (or toggle **All files access** for the app in the headset's app settings). Without it, installs fail with `pbsControlAPPManger returned 102: APK does not exist`.
+> (or toggle **All files access** for the app in the headset's app settings). The client's own settings screen also shows the current grant status and a **Grant All Files Access** button that opens this settings page. Without it, installs fail with `pbsControlAPPManger returned 102: APK does not exist`.
 
 ## Documentation
 

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
@@ -1,10 +1,16 @@
 package com.styly.mdmclient
 
+import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
+import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -21,6 +27,8 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var statusText: TextView
     private lateinit var saveButton: Button
     private lateinit var discoverButton: Button
+    private lateinit var storagePermissionStatus: TextView
+    private lateinit var grantStorageButton: Button
 
     private val statusReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -38,6 +46,8 @@ class SettingsActivity : AppCompatActivity() {
         statusText = findViewById(R.id.status_text)
         saveButton = findViewById(R.id.save_button)
         discoverButton = findViewById(R.id.discover_button)
+        storagePermissionStatus = findViewById(R.id.storage_permission_status)
+        grantStorageButton = findViewById(R.id.grant_storage_button)
 
         // Load current server URL
         val prefs = getSharedPreferences("stylymdm_prefs", MODE_PRIVATE)
@@ -52,6 +62,10 @@ class SettingsActivity : AppCompatActivity() {
             discoverServer()
         }
 
+        grantStorageButton.setOnClickListener {
+            requestAllFilesAccess()
+        }
+
         // Start the service if not already running
         startForegroundService(Intent(this, MdmClientService::class.java))
     }
@@ -60,6 +74,8 @@ class SettingsActivity : AppCompatActivity() {
         super.onResume()
         val filter = IntentFilter(MdmClientService.ACTION_STATUS_UPDATE)
         registerReceiver(statusReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        // Re-check here so returning from the system settings screen refreshes the UI.
+        updateStoragePermissionUi()
     }
 
     override fun onPause() {
@@ -98,6 +114,46 @@ class SettingsActivity : AppCompatActivity() {
         startForegroundService(Intent(this, MdmClientService::class.java))
 
         statusText.text = "Reconnecting..."
+    }
+
+    /**
+     * MANAGE_EXTERNAL_STORAGE ("All files access") is required so the PICO ToBService can read
+     * downloaded APKs from shared storage. It is an appop, not a runtime permission, so it cannot
+     * be requested with a standard permission dialog — the user is sent to the system settings.
+     */
+    private fun hasAllFilesAccess(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.R || Environment.isExternalStorageManager()
+    }
+
+    private fun updateStoragePermissionUi() {
+        if (hasAllFilesAccess()) {
+            storagePermissionStatus.setText(R.string.storage_permission_granted)
+            storagePermissionStatus.setTextColor(0xFF4CAF50.toInt())
+            grantStorageButton.visibility = View.GONE
+        } else {
+            storagePermissionStatus.setText(R.string.storage_permission_not_granted)
+            storagePermissionStatus.setTextColor(0xFFFF5722.toInt())
+            grantStorageButton.visibility = View.VISIBLE
+        }
+    }
+
+    private fun requestAllFilesAccess() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        val packageUri = Uri.fromParts("package", packageName, null)
+        // Prefer the per-app screen; fall back to the global list for OEMs that lack it.
+        val candidates = listOf(
+            Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, packageUri),
+            Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+        )
+        for (intent in candidates) {
+            try {
+                startActivity(intent)
+                return
+            } catch (e: ActivityNotFoundException) {
+                // Try the next fallback.
+            }
+        }
+        Toast.makeText(this, R.string.storage_permission_settings_unavailable, Toast.LENGTH_LONG).show()
     }
 
     private fun updateStatusDisplay(connected: Boolean, message: String) {

--- a/mdm-client/app/src/main/res/layout/activity_settings.xml
+++ b/mdm-client/app/src/main/res/layout/activity_settings.xml
@@ -59,4 +59,26 @@
         android:textSize="16sp"
         android:textStyle="bold" />
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/storage_permission_label"
+        android:textSize="14sp"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:id="@+id/storage_permission_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <Button
+        android:id="@+id/grant_storage_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/grant_all_files_access" />
+
 </LinearLayout>

--- a/mdm-client/app/src/main/res/values/strings.xml
+++ b/mdm-client/app/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
     <string name="save_and_connect">Save &amp; Connect</string>
     <string name="connection_status_label">Connection Status</string>
     <string name="status_unknown">Not connected</string>
+    <string name="storage_permission_label">All Files Access</string>
+    <string name="grant_all_files_access">Grant All Files Access</string>
+    <string name="storage_permission_granted">Granted</string>
+    <string name="storage_permission_not_granted">Not granted — required to install APKs</string>
+    <string name="storage_permission_settings_unavailable">Could not open the All Files Access settings on this device</string>
 </resources>


### PR DESCRIPTION
## Why

Installing an APK from the web console fails with:

> All files access (MANAGE_EXTERNAL_STORAGE) is not granted on this device

The PICO ToBService runs as a separate system-user process and reads downloaded APKs from shared storage, which requires the `MANAGE_EXTERNAL_STORAGE` ("All files access") appop. Until now the only way to grant it was `adb shell appops set ... allow` during provisioning. On sites without adb access there was no in-app path, and the failure was opaque.

`MANAGE_EXTERNAL_STORAGE` is an appop, not a runtime permission, so it cannot be requested with a standard permission dialog — the user must be sent to the system settings page.

## What

The client settings screen (`SettingsActivity`) now has an **All Files Access** section:

- Shows the current grant status — **Granted** (green) or **Not granted — required to install APKs** (red).
- When not granted, shows a **Grant All Files Access** button that deep-links to `ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION` (the per-app screen), falling back to `ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION` (the global list) for OEMs that lack the per-app intent.
- Re-checks in `onResume`, so returning from the settings screen refreshes the status and hides the button once granted.

`hasAllFilesAccess()` mirrors the existing `MdmClientService.hasExternalStorageAccess()` check. README updated to mention the in-app path alongside the existing `adb appops` command.

This does not replace the `adb appops set` provisioning flow — for fleets that remains the simplest path. It adds a manual fallback; it is not fully silent (the user still toggles the OS setting).

## Verification

- `./gradlew :app:compileDebugKotlin` — `BUILD SUCCESSFUL`.
- Verified on a real device: button appears when ungranted, opens the settings page, and the status flips to **Granted** (button hidden) after returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)