### PR TITLE
Add release version-bump workflow; build APK on publish

### DIFF
--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -1,0 +1,138 @@
+name: 'Release: bump version & draft'
+
+# Manually triggered. Given a versionName, this workflow:
+#   1. Bumps versionName in mdm-client/app/build.gradle and auto-increments versionCode.
+#   2. Commits the bump to develop.
+#   3. Creates a DRAFT GitHub Release tagged vX.Y.Z targeting develop.
+#
+# It intentionally stops at a draft. Publishing the draft is a MANUAL step, and that human
+# publish is what triggers release.yml to build and attach the signed APK. This is required:
+# a workflow using the default GITHUB_TOKEN cannot trigger another workflow, so auto-publishing
+# here would silently suppress the `release: published` event and the APK would never build.
+# (If auto-publish is ever wanted, release.yml would have to be triggered via a PAT instead.)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'versionName (semver, e.g. 0.2.0). versionCode is auto-incremented.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bump-and-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0 # Full history so the bump commit pushes cleanly.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        env:
+          # Pass via env (never interpolate untrusted ${{ ... }} directly into the shell).
+          VERSION_INPUT: ${{ github.event.inputs.version }}
+        run: |
+          # Strip a leading v/V if present.
+          VERSION="${VERSION_INPUT#[vV]}"
+          if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$' > /dev/null; then
+            echo "::error::Invalid version format: '$VERSION' (expected semver, e.g. 0.2.0 or 0.2.0-beta.1)"
+            exit 1
+          fi
+          # Safe to export now: the regex above guarantees VERSION is semver-only.
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "✅ Version format valid: $VERSION"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure develop is up to date
+        run: |
+          git fetch origin develop
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/develop)" ]; then
+            echo "::error::Local develop is not in sync with origin/develop. Re-run after the workflow checks out the latest develop."
+            exit 1
+          fi
+          echo "✅ develop is up to date"
+
+      - name: Bump versionName and versionCode
+        run: |
+          BUILD_GRADLE="mdm-client/app/build.gradle"
+          [ -f "$BUILD_GRADLE" ] || { echo "::error::$BUILD_GRADLE not found"; exit 1; }
+
+          CURRENT_NAME=$(grep -E '^[[:space:]]*versionName[[:space:]]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/.*versionName[[:space:]]+"([^"]*)".*/\1/')
+          CURRENT_CODE=$(grep -E '^[[:space:]]*versionCode[[:space:]]+[0-9]+' "$BUILD_GRADLE" | head -1 | grep -oE '[0-9]+')
+          [ -n "$CURRENT_CODE" ] || { echo "::error::Could not read current versionCode from $BUILD_GRADLE"; exit 1; }
+          NEW_CODE=$((CURRENT_CODE + 1))
+
+          echo "versionName: $CURRENT_NAME -> $VERSION"
+          echo "versionCode: $CURRENT_CODE -> $NEW_CODE"
+
+          sed -i -E "s/^([[:space:]]*)versionName[[:space:]]+\".*\"/\1versionName \"$VERSION\"/" "$BUILD_GRADLE"
+          sed -i -E "s/^([[:space:]]*)versionCode[[:space:]]+[0-9]+/\1versionCode $NEW_CODE/" "$BUILD_GRADLE"
+
+          # Re-read and verify the edit landed exactly as intended.
+          AFTER_NAME=$(grep -E '^[[:space:]]*versionName[[:space:]]+"' "$BUILD_GRADLE" | head -1 | sed -E 's/.*versionName[[:space:]]+"([^"]*)".*/\1/')
+          AFTER_CODE=$(grep -E '^[[:space:]]*versionCode[[:space:]]+[0-9]+' "$BUILD_GRADLE" | head -1 | grep -oE '[0-9]+')
+          if [ "$AFTER_NAME" != "$VERSION" ] || [ "$AFTER_CODE" != "$NEW_CODE" ]; then
+            echo "::error::build.gradle verification failed (versionName=$AFTER_NAME versionCode=$AFTER_CODE)"
+            exit 1
+          fi
+
+          echo "NEW_CODE=$NEW_CODE" >> "$GITHUB_ENV"
+          echo "CURRENT_NAME=$CURRENT_NAME" >> "$GITHUB_ENV"
+
+      - name: Commit and push to develop
+        run: |
+          git add mdm-client/app/build.gradle
+          if git diff --staged --quiet; then
+            echo "::error::No changes to commit — version may already be $VERSION."
+            exit 1
+          fi
+          git commit -m "chore: bump version to $VERSION (versionCode $NEW_CODE)"
+          git push origin develop
+          echo "✅ Pushed version bump to develop"
+
+      - name: Create draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v$VERSION"
+          gh release create "$TAG" \
+            --draft \
+            --target develop \
+            --title "$TAG" \
+            --generate-notes
+          echo "✅ Draft release created: $TAG (targeting develop)"
+          echo "👉 Review the notes and click **Publish release** to build & attach the signed APK."
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "# 📦 Release version bump"
+            echo ""
+            if [ "${{ job.status }}" == "success" ]; then
+              echo "| Field | From | To |"
+              echo "|-------|------|----|"
+              echo "| versionName | \`${CURRENT_NAME}\` | \`${VERSION}\` |"
+              echo "| versionCode | (prev) | \`${NEW_CODE}\` |"
+              echo ""
+              echo "Draft release **\`v${VERSION}\`** created (target: \`develop\`)."
+              echo ""
+              echo "### Next step"
+              echo "Edit the notes and **Publish** the draft. That fires \`release.yml\`, which builds and attaches the signed APK."
+              echo ""
+              echo "[Open releases](https://github.com/${{ github.repository }}/releases)"
+            else
+              echo "## ❌ Failed"
+              echo "Check the logs above. Common causes: invalid version, develop branch protection blocking the push, or version already set."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Build and Release APK
 
 on:
   release:
-    types: [created]
+    # Fires when a release is published (including publishing a draft created by
+    # release-version-bump.yml). Draft creation does not trigger any release event,
+    # so the version-bump workflow stops at a draft and a human publish starts this build.
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
## Why

Today the APK build is automated (`release.yml`), but the steps *before* it are manual: editing `versionName`/`versionCode` in `build.gradle`, committing, tagging, and creating the release. STYLY-NetSync already automates this via a dispatchable `release-workflow.yml`; this PR brings the same idea to MDM (adapted for a single Android app with no `main` branch).

It also closes the gap from the v0.1.0 bump, where `versionCode` was left at `1` — Android rejects an update install unless `versionCode` strictly increases.

## What

**New: `.github/workflows/release-version-bump.yml`** (manual `workflow_dispatch`, input = `version`):
1. Validates the version is semver (input passed via `env:`, not interpolated into the shell).
2. Checks `develop` is up to date.
3. Bumps `versionName` to the input and **auto-increments `versionCode`** in `mdm-client/app/build.gradle` (re-reads to verify the edit).
4. Commits `chore: bump version to X (versionCode N)` to `develop`.
5. Creates a **draft** GitHub Release `vX.Y.Z` (target `develop`, `--generate-notes`).

**Changed: `release.yml`** trigger `created` → `published`.

## Release flow after this PR

1. Run **Release: bump version & draft** with a version (e.g. `0.2.0`).
2. Review/edit the auto-generated draft notes.
3. **Publish** the draft → `release.yml` builds and attaches the signed APK.

## Design notes (please keep)

- **The manual publish is the trigger, not just review polish.** A workflow using the default `GITHUB_TOKEN` cannot trigger another workflow, so the bump workflow deliberately stops at a draft — a *human* publish fires the `published` event that `release.yml` listens for. Auto-publishing here would silently break the APK build (it would need a PAT instead).
- `published` (not `created`) is used alone: it covers draft→publish **and** direct publishes, without the double-build that keeping `created` alongside would cause.
- `--target develop` means the tag is cut at develop's HEAD **at publish time** (latest develop ships; the version string is correct because the bump is on develop).

## Prerequisites / caveats

- Must be merged to `develop` before it appears in the Actions UI (`workflow_dispatch` runs from the default branch).
- The workflow pushes the bump commit directly to `develop`. If `develop` has branch protection requiring PRs, the push step needs an allowance (or the bot must be exempt).
- `workflow_dispatch` can't be dry-run before merge; the `versionCode` increment + `sed` rewrite logic was tested locally against `build.gradle` (1 → 2, name 0.1.0 → 0.2.0, indentation preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)