### PR TITLE
Clear the APK File selection after each Quick Install

### DIFF
--- a/mdm-server/static/index.html
+++ b/mdm-server/static/index.html
@@ -1354,6 +1354,14 @@
               updateInstallCell(id);
             });
             addLog('Installing ' + apk.apk_filename + ' on ' + online.length + ' device(s)', 'info');
+            // Clear the selection after each install. Over a LAN (non-secure context) the
+            // browser only holds a one-time File snapshot and cannot detect a local rebuild,
+            // so we force a fresh pick next time — this prevents silently re-installing a
+            // stale APK after the .apk has been rebuilt.
+            apkFile.value = '';
+            uploadedApk = null;
+            apkSummary.textContent = 'No APK selected';
+            updateButtons();
           })
           .catch(function (err) {
             apkSummary.textContent = 'Upload failed';


### PR DESCRIPTION
## Summary
Reset the Quick Install APK file picker after each install so the next install
requires re-selecting the APK.

## Why
After rebuilding the APK locally, the picker still holds the previously selected
(now stale) file, so pressing Install again would silently re-install the old
build. Clearing the selection after each install forces you to re-select the APK
before the next install, so a stale build can't be re-installed by mistake.

## Changes
- On a successful install, clear the file input and cached upload, and reset the
  summary/buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)