### PR TITLE
Add Context7 MCP config for PICO Business docs (#16)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,29 @@
 - **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
 - **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
 - **English Only**: All code comments, log messages, and user-facing strings must be written in English.
+
+## External Documentation (Context7)
+
+When implementing, modifying, reviewing, or debugging anything related to PICO
+enterprise devices — device management, enterprise deployment, the PICO
+Enterprise SDK (TobService), silent app install/uninstall, device owner
+settings, permissions, or Android manifest settings for PICO devices — use
+Context7 before writing code.
+
+Primary reference:
+
+- **PICO Business documentation**
+- Context7 URL: https://context7.com/websites/business_picoxr_us_doc
+- Preferred Context7 library ID: `/websites/business_picoxr_us_doc`
+
+Query the exact library ID `/websites/business_picoxr_us_doc` directly instead
+of doing a generic library search.
+
+Do not rely only on memory for PICO Enterprise SDK APIs, permissions, Android
+manifest settings, enterprise deployment behavior, device management behavior,
+or version-specific behavior. Check the current Context7 documentation first.
+
+Claude Code picks up the Context7 MCP server automatically from the
+project-scoped `.mcp.json`. For Codex, register it once with
+`codex mcp add context7 --url https://mcp.context7.com/mcp` (Codex does not
+read a project-local `.codex/config.toml`).


### PR DESCRIPTION
## Summary

Configures the Context7 MCP server so agents reference the **PICO Business / Enterprise SDK (TobService)** documentation when working on PICO device-management features in this MDM client. Addresses #16.

- **`.mcp.json`** (new): project-scoped Context7 MCP for Claude Code (HTTP `https://mcp.context7.com/mcp`). Picked up automatically; first use prompts a one-time project-trust approval.
- **`AGENTS.md`**: new "External Documentation (Context7)" section instructing agents to query the PICO Business docs (library ID `/websites/business_picoxr_us_doc`) before writing PICO-related code, plus the Codex setup one-liner.

## Verification

- `claude mcp get context7` → `Scope: Project config (shared via .mcp.json)`, type `http`. Detected at **project scope**. ✅
- Sample query to `/websites/business_picoxr_us_doc` returns real PICO Enterprise API content (silent install/uninstall, device owner, etc.). ✅

## Deviations from the issue (intentional)

- **Unity coding rules omitted.** This repo is Android/Kotlin (`mdm-client` + `mdm-server`) with zero Unity, so the proposed Unity rules (`UnityEngine.Object` null-propagation, Unity main thread) don't apply. The existing "English Only" principle in AGENTS.md is retained.
- **No committed `.codex/config.toml`.** Verified empirically that Codex 0.137.0 does **not** auto-load a project-local `./.codex/config.toml` (only loads it via `CODEX_HOME`, which would clobber global auth/model/plugins). Codex therefore cannot have repo-managed MCP config. Each developer registers it once, per-machine:
  `codex mcp add context7 --url https://mcp.context7.com/mcp`
  (documented in AGENTS.md). Confirmed and set up via Codex itself.

## Notes

- No API key required.
- The Codex "detect from repository-level configuration" acceptance criterion cannot be met as written due to the Codex limitation above; the per-machine workaround is documented instead. Leaving #16 open for maintainer review rather than auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)