### PR TITLE
[codex] Add Context7 project config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,14 @@
+# Codex configuration for the STYLY-MDM repository.
+#
+# Context7 MCP server: provides the latest PICO Business / Enterprise SDK
+# (TobService) documentation. Prefer querying the library ID
+# /websites/business_picoxr_us_doc for PICO-related work.
+#
+# Codex CLI 0.141.0 loads project-local .codex/config.toml files for trusted
+# projects. If Context7 is not listed by `codex mcp list`, trust this project
+# or register the server in the user-level config with:
+#   codex mcp add context7 --url https://mcp.context7.com/mcp
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+enabled = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ manifest settings, enterprise deployment behavior, device management behavior,
 or version-specific behavior. Check the current Context7 documentation first.
 
 Claude Code picks up the Context7 MCP server automatically from the
-project-scoped `.mcp.json`. For Codex, register it once with
-`codex mcp add context7 --url https://mcp.context7.com/mcp` (Codex does not
-read a project-local `.codex/config.toml`).
+project-scoped `.mcp.json`. Codex CLI 0.141.0 and later can read the
+project-scoped `.codex/config.toml` when the project is trusted. If Context7 is
+not listed by `codex mcp list`, trust this project or register the server in
+the user-level config with:
+
+```bash
+codex mcp add context7 --url https://mcp.context7.com/mcp
+```


### PR DESCRIPTION
## Summary

- Add project-local Codex configuration for the Context7 MCP server.
- Update `AGENTS.md` to describe Codex CLI 0.141.0+ project config behavior and the user-level fallback command.

## Validation

- `git diff --check HEAD^ HEAD`

## Notes

- This PR only includes the staged `.codex/config.toml` and `AGENTS.md` changes.


Close https://github.com/styly-dev/STYLY-MDM/issues/16