### PR TITLE
docs: enforce DEVELOPMENT.md sync and ignore tasks/todo.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ mdm-client/local.properties
 mdm-server/device_registry.json
 mdm-server/device_registry.json.tmp
 
+# === Agent workflow scratch ===
+# Per-task scratch plan, rewritten every task. tasks/lessons.md is intentionally
+# NOT ignored: it accumulates persistent lessons meant to be shared via git.
+tasks/todo.md
+
 # === Misc ===
 nanobanana-output/*.png
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Diff behavior between main and your changes when relevant
 - Ask yourself: "Would a staff engineer approve this?"
 - Run tests, check logs, demonstrate correctness
+- When a change adds a new feature or alters the architecture, update `docs/DEVELOPMENT.md` (and its diagrams) in the same change
 
 ### 5. Demand Elegance (Balanced)
 - For non-trivial changes: pause and ask "is there a more elegant way?"
@@ -51,6 +52,7 @@
 - **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
 - **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
 - **English Only**: All code comments, log messages, and user-facing strings must be written in English.
+- **Docs in Sync**: Keep `docs/DEVELOPMENT.md` up to date. Any new feature or architectural change must be reflected there (including the `architecture.drawio.svg` / `message-flow.drawio.svg` diagrams when relevant) as part of the same change.
 
 ## External Documentation (Context7)
 


### PR DESCRIPTION
## Summary
Process/documentation maintenance changes to `AGENTS.md` and `.gitignore`.

- **AGENTS.md**: Require `docs/DEVELOPMENT.md` (and its `architecture.drawio.svg` / `message-flow.drawio.svg` diagrams when relevant) to be updated **in the same change** whenever a feature or architecture is added or altered. Captured in two places:
  - A new **Verification Before Done** checklist item.
  - A new **Docs in Sync** core principle.
- **.gitignore**: Ignore the per-task scratch file `tasks/todo.md`, while intentionally keeping the persistent `tasks/lessons.md` tracked (it's shared knowledge meant to live in git).

## Notes
- No code changes; docs/config only.
- The pre-existing `cSpell` warnings about "picoxr" come from the Context7 URLs and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wLc5WY9DtWHTgqbgSxL6R