### PR TITLE
feat: separate dev/prod discovery ports for parallel testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,12 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: gradle assembleRelease
+        run: gradle assembleProdRelease
 
       - name: Upload APK to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          APK=$(find mdm-client/app/build/outputs/apk/release -name "*.apk" | head -1)
+          APK=$(find mdm-client/app/build/outputs/apk/prod/release -name "*.apk" | head -1)
           gh release upload "$RELEASE_TAG" "$APK" --clobber

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,11 +24,16 @@ For end-user setup and usage, see the [README](../README.md).
 
 ```bash
 cd mdm-client
-./build.sh          # debug build
-./build.sh release  # release build
+./build.sh                # prod debug (default)
+./build.sh release        # prod release
+./build.sh debug dev      # dev debug   — separate discovery port (see below)
+./build.sh release dev    # dev release
 ```
 
-The generated APK is output to `mdm-client/app/build/outputs/apk/debug/` (or `release/`).
+Usage: `./build.sh [debug|release] [prod|dev]` (defaults: `debug prod`).
+
+The generated APK is output to `mdm-client/app/build/outputs/apk/<flavor>/<type>/`,
+e.g. `apk/prod/debug/app-prod-debug.apk` or `apk/dev/debug/app-dev-debug.apk`.
 
 ### Build from Android Studio
 
@@ -38,10 +43,56 @@ The generated APK is output to `mdm-client/app/build/outputs/apk/debug/` (or `re
 ### Install the APK
 
 ```bash
-adb install mdm-client/app/build/outputs/apk/debug/app-debug.apk
+adb install mdm-client/app/build/outputs/apk/prod/debug/app-prod-debug.apk
 ```
 
 > **Dev Container:** A ready-to-use build environment is provided via [Dev Containers](https://containers.dev/). Open this repository in VS Code with the Dev Containers extension (or GitHub Codespaces) and all prerequisites (JDK 17, Android SDK 33, build-tools, Gradle) are set up automatically — no local installation needed.
+
+## Running a Dev Environment Alongside Production
+
+Only one production server may exist per LAN (clients connect to the first server
+that answers discovery). During development you often want a separate dev server and
+dev client on the **same** network without disturbing production. The `dev` build
+flavor and a pair of server environment variables isolate the two by using different
+ports, so neither environment discovers the other.
+
+| Environment | Discovery port | WebSocket port | Client applicationId |
+|---|---|---|---|
+| Production (default) | 7071 | 7070 | `com.styly.mdmclient` |
+| Development (`dev` flavor) | 7081 | 7080 | `com.styly.mdmclient.dev` |
+
+**Dev server** — start with the `dev` argument, which sets the dev ports for you:
+
+```bash
+cd mdm-server
+./run.sh dev      # dev ports (7081 / 7080); ./run.sh (or "prod") uses production ports
+```
+
+`run.sh dev` simply exports `MDM_DISCOVERY_PORT=7081` / `MDM_WS_PORT=7080` before
+launching `server.py`. You can still set those variables yourself if you prefer.
+When unset, `server.py` falls back to the production ports, so production startup is
+unchanged.
+
+**Dev client** — build the `dev` flavor:
+
+```bash
+cd mdm-client
+./build.sh debug dev      # or: ./build.sh release dev
+adb install app/build/outputs/apk/dev/debug/app-dev-debug.apk
+```
+
+The dev APK uses applicationId `com.styly.mdmclient.dev` and label **STYLY-MDM Dev**,
+so it installs side-by-side with the production build on the same headset. It only
+broadcasts/listens on the dev discovery port (7081), so it never discovers the
+production server. Its fallback URL also targets the dev WebSocket port (7080), so
+even if discovery times out it cannot accidentally connect to a production server.
+
+The ports come from `BuildConfig` fields defined per flavor in
+`mdm-client/app/build.gradle` (`DISCOVERY_PORT`, `DEFAULT_WS_PORT`).
+
+> **Device owner:** Android allows only one device owner per device. If you provision
+> the dev build as device owner for testing, the production build cannot hold
+> device-owner powers at the same time.
 
 ## Project Structure
 
@@ -117,6 +168,10 @@ STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.
 | 2 | Server → Client | Respond with JSON: `{"service": "stylymdm", "ws_url": "ws://<ip>:7070/ws/device", "version": "1.0"}` |
 
 The client waits up to 3 seconds for a response. If no server replies, discovery fails silently and the client falls back to the default or saved URL.
+
+> The ports above are the production defaults. A development server/client uses
+> port 7081 (discovery) and 7080 (WebSocket) instead — see
+> [Running a Dev Environment Alongside Production](#running-a-dev-environment-alongside-production).
 
 ## MDM Client Permissions
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,10 +56,16 @@ dev client on the **same** network without disturbing production. The `dev` buil
 flavor and a pair of server environment variables isolate the two by using different
 ports, so neither environment discovers the other.
 
-| Environment | Discovery port | WebSocket port | Client applicationId |
+| Environment | Discovery port | WebSocket port | Client build (label) |
 |---|---|---|---|
-| Production (default) | 7071 | 7070 | `com.styly.mdmclient` |
-| Development (`dev` flavor) | 7081 | 7080 | `com.styly.mdmclient.dev` |
+| Production (default) | 7071 | 7070 | `prod` flavor — "STYLY-MDM Client" |
+| Development (`dev` flavor) | 7081 | 7080 | `dev` flavor — "STYLY-MDM Dev" |
+
+Both flavors share the applicationId `com.styly.mdmclient`, so they **cannot be
+installed at the same time** — installing the dev build replaces the production build
+on a device. Run the dev client on a dedicated test device, or accept that it replaces
+production while you test. Isolation between the two environments is purely by port, so
+a dev client/server never discovers a production one even on the same LAN.
 
 **Dev server** — start with the `dev` argument, which sets the dev ports for you:
 
@@ -81,18 +87,22 @@ cd mdm-client
 adb install app/build/outputs/apk/dev/debug/app-dev-debug.apk
 ```
 
-The dev APK uses applicationId `com.styly.mdmclient.dev` and label **STYLY-MDM Dev**,
-so it installs side-by-side with the production build on the same headset. It only
-broadcasts/listens on the dev discovery port (7081), so it never discovers the
-production server. Its fallback URL also targets the dev WebSocket port (7080), so
-even if discovery times out it cannot accidentally connect to a production server.
+The dev APK keeps the production applicationId `com.styly.mdmclient` and only changes
+its label to **STYLY-MDM Dev**, so installing it replaces the production build on a
+device (they share a package name and cannot coexist). It only broadcasts/listens on
+the dev discovery port (7081), so it never discovers the production server. Its
+fallback URL also targets the dev WebSocket port (7080), so even if discovery times
+out it cannot accidentally connect to a production server.
 
 The ports come from `BuildConfig` fields defined per flavor in
 `mdm-client/app/build.gradle` (`DISCOVERY_PORT`, `DEFAULT_WS_PORT`).
 
-> **Device owner:** Android allows only one device owner per device. If you provision
-> the dev build as device owner for testing, the production build cannot hold
-> device-owner powers at the same time.
+> **Device owner:** because dev and prod share an applicationId, a device only ever has
+> one STYLY-MDM install, so there is never a dev-vs-prod device-owner conflict on a
+> single device. Updating a device-owner production install in place with a dev build
+> of the **same signing key** preserves device-owner status; a differently signed dev
+> build (e.g. debug over a release install) must be uninstalled first, which clears
+> device-owner status, so you would need to re-provision.
 
 ## Project Structure
 

--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -50,12 +50,14 @@ android {
             buildConfigField "int", "DISCOVERY_PORT", "7071"
             buildConfigField "int", "DEFAULT_WS_PORT", "7070"
         }
-        // Development: separate discovery port so a dev server/APK can coexist with
-        // production on the same LAN. The ".dev" applicationId lets the dev build be
-        // installed side-by-side with the production build on the same headset.
+        // Development: separate discovery/WebSocket ports so a dev server/client can run
+        // on the same LAN as production without the two discovering each other. The
+        // applicationId is intentionally identical to prod (no suffix), so the dev build
+        // is NOT installed side-by-side — installing it replaces the production build on a
+        // device. Use a dedicated test device (or accept the replacement while testing).
+        // The "-dev" versionName and "STYLY-MDM Dev" label show which build is installed.
         dev {
             dimension "environment"
-            applicationIdSuffix ".dev"
             versionNameSuffix "-dev"
             buildConfigField "int", "DISCOVERY_PORT", "7081"
             buildConfigField "int", "DEFAULT_WS_PORT", "7080"

--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -37,6 +37,31 @@ android {
         }
     }
 
+    buildFeatures {
+        // Required on AGP 8+ to generate BuildConfig with our custom fields.
+        buildConfig true
+    }
+
+    flavorDimensions += "environment"
+    productFlavors {
+        // Production: ships to real devices on the production server's discovery port.
+        prod {
+            dimension "environment"
+            buildConfigField "int", "DISCOVERY_PORT", "7071"
+            buildConfigField "int", "DEFAULT_WS_PORT", "7070"
+        }
+        // Development: separate discovery port so a dev server/APK can coexist with
+        // production on the same LAN. The ".dev" applicationId lets the dev build be
+        // installed side-by-side with the production build on the same headset.
+        dev {
+            dimension "environment"
+            applicationIdSuffix ".dev"
+            versionNameSuffix "-dev"
+            buildConfigField "int", "DISCOVERY_PORT", "7081"
+            buildConfigField "int", "DEFAULT_WS_PORT", "7080"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/mdm-client/app/src/dev/res/values/strings.xml
+++ b/mdm-client/app/src/dev/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overrides the launcher label for the dev flavor so it's distinguishable
+         from the production build when both are installed on the same device. -->
+    <string name="app_name">STYLY-MDM Dev</string>
+    <!-- Dev uses the dev ws port (7080) so the placeholder doesn't point at prod. -->
+    <string name="server_url_hint">ws://192.168.1.100:7080/ws/device</string>
+</resources>

--- a/mdm-client/app/src/dev/res/values/strings.xml
+++ b/mdm-client/app/src/dev/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Overrides the launcher label for the dev flavor so it's distinguishable
-         from the production build when both are installed on the same device. -->
+    <!-- Overrides the launcher label for the dev flavor so you can tell at a glance
+         which build is installed. dev and prod share an applicationId and therefore
+         cannot be installed at the same time. -->
     <string name="app_name">STYLY-MDM Dev</string>
     <!-- Dev uses the dev ws port (7080) so the placeholder doesn't point at prod. -->
     <string name="server_url_hint">ws://192.168.1.100:7080/ws/device</string>

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/ServerDiscovery.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/ServerDiscovery.kt
@@ -8,13 +8,14 @@ import java.net.InetAddress
 
 /**
  * Discovers STYLY-MDM servers on the local network using UDP broadcast.
- * Sends a discovery request to the broadcast address on port 7071
- * and waits for a JSON response containing the server's WebSocket URL.
+ * Sends a discovery request to the broadcast address on the build flavor's
+ * discovery port (prod/dev differ so they don't find each other's server) and
+ * waits for a JSON response containing the server's WebSocket URL.
  */
 object ServerDiscovery {
 
     private const val TAG = "ServerDiscovery"
-    private const val DISCOVERY_PORT = 7071
+    private val DISCOVERY_PORT = BuildConfig.DISCOVERY_PORT
     private const val DISCOVERY_MESSAGE = "STYLYMDM_DISCOVER"
     private const val TIMEOUT_MS = 3000
 

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
@@ -51,7 +51,7 @@ class SettingsActivity : AppCompatActivity() {
 
         // Load current server URL
         val prefs = getSharedPreferences("stylymdm_prefs", MODE_PRIVATE)
-        val currentUrl = prefs.getString("server_url", "ws://192.168.1.100:7070/ws/device") ?: ""
+        val currentUrl = prefs.getString("server_url", WebSocketManager.DEFAULT_SERVER_URL) ?: ""
         serverUrlInput.setText(currentUrl)
 
         saveButton.setOnClickListener {

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
@@ -31,7 +31,11 @@ class WebSocketManager(
         private const val TAG = "WebSocketManager"
         const val PREF_NAME = "stylymdm_prefs"
         private const val PREF_SERVER_URL = "server_url"
-        private const val DEFAULT_SERVER_URL = "ws://192.168.1.100:7070/ws/device"
+        // Last-resort fallback used only when discovery fails and no URL is saved.
+        // The port is flavor-aware (BuildConfig.DEFAULT_WS_PORT) so the dev build
+        // never falls back to the production port and accidentally connects to a
+        // production server. The IP is just a placeholder; discovery is the real path.
+        val DEFAULT_SERVER_URL = "ws://192.168.1.100:${BuildConfig.DEFAULT_WS_PORT}/ws/device"
         private const val INITIAL_RECONNECT_DELAY_MS = 1000L
         private const val MAX_RECONNECT_DELAY_MS = 30000L
         private const val DISCOVERY_INTERVAL_MS = 15000L

--- a/mdm-client/build.sh
+++ b/mdm-client/build.sh
@@ -17,22 +17,34 @@ if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ]; then
 fi
 
 # --- build -------------------------------------------------------------------
+# Usage: ./build.sh [debug|release] [prod|dev]
+# Flavors: prod = production (discovery port 7071), dev = development (port 7081,
+# applicationId ".dev" so it installs alongside prod for side-by-side testing).
 BUILD_TYPE="${1:-debug}"
+FLAVOR="${2:-prod}"
 
 case "$BUILD_TYPE" in
-    debug)   TASK="assembleDebug"   ;;
-    release) TASK="assembleRelease" ;;
+    debug)   TYPE_CAP="Debug"   ;;
+    release) TYPE_CAP="Release" ;;
     *)       error "Unknown build type: $BUILD_TYPE (specify debug or release)" ;;
 esac
 
-info "Building MDM Client APK (${BUILD_TYPE}) ..."
+case "$FLAVOR" in
+    prod) FLAVOR_CAP="Prod" ;;
+    dev)  FLAVOR_CAP="Dev"  ;;
+    *)    error "Unknown flavor: $FLAVOR (specify prod or dev)" ;;
+esac
+
+TASK="assemble${FLAVOR_CAP}${TYPE_CAP}"
+
+info "Building MDM Client APK (${FLAVOR} ${BUILD_TYPE}) ..."
 # Use the Gradle wrapper, not a system-wide `gradle`. The wrapper pins the Gradle
 # version (gradle/wrapper/gradle-wrapper.properties) that the configured AGP requires;
 # a mismatched system Gradle fails the AGP version check.
 ./gradlew "$TASK"
 
 # --- output ------------------------------------------------------------------
-APK=$(find app/build/outputs/apk/"$BUILD_TYPE" -name "*.apk" 2>/dev/null | head -1)
+APK=$(find app/build/outputs/apk/"$FLAVOR"/"$BUILD_TYPE" -name "*.apk" 2>/dev/null | head -1)
 
 if [ -z "$APK" ]; then
     error "APK not found."

--- a/mdm-client/build.sh
+++ b/mdm-client/build.sh
@@ -18,8 +18,8 @@ fi
 
 # --- build -------------------------------------------------------------------
 # Usage: ./build.sh [debug|release] [prod|dev]
-# Flavors: prod = production (discovery port 7071), dev = development (port 7081,
-# applicationId ".dev" so it installs alongside prod for side-by-side testing).
+# Flavors: prod = production (discovery port 7071), dev = development (port 7081).
+# dev shares prod's applicationId, so installing it replaces a prod install on a device.
 BUILD_TYPE="${1:-debug}"
 FLAVOR="${2:-prod}"
 

--- a/mdm-server/run.sh
+++ b/mdm-server/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- helpers ----------------------------------------------------------------
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$1" >&2; exit 1; }
+
+# --- prerequisite checks ----------------------------------------------------
+command -v python >/dev/null 2>&1 || error "python not found. Please install Python 3.10+."
+
+# --- environment ------------------------------------------------------------
+# Usage: ./run.sh [prod|dev]   (default: prod)
+# Dev uses separate discovery/WebSocket ports so a dev server can run on the same
+# LAN as production without the two stealing each other's clients. Keep these in
+# sync with the client's dev flavor in mdm-client/app/build.gradle (DISCOVERY_PORT,
+# DEFAULT_WS_PORT).
+ENVIRONMENT="${1:-prod}"
+
+case "$ENVIRONMENT" in
+    prod)
+        # server.py falls back to the production ports (7071 / 7070) when unset.
+        ;;
+    dev)
+        export MDM_DISCOVERY_PORT=7081
+        export MDM_WS_PORT=7080
+        ;;
+    *)
+        error "Unknown environment: $ENVIRONMENT (specify prod or dev)"
+        ;;
+esac
+
+# --- run --------------------------------------------------------------------
+info "Starting STYLY-MDM server (${ENVIRONMENT}) ..."
+exec python server.py

--- a/mdm-server/server.py
+++ b/mdm-server/server.py
@@ -8,6 +8,7 @@ Static files for the web console are served from ./static/.
 import asyncio
 import json
 import logging
+import os
 import re
 import socket
 import time
@@ -686,7 +687,10 @@ async def handle_clear_startup_app(admin_ws: web.WebSocketResponse, data: dict):
 # UDP Discovery Responder
 # ---------------------------------------------------------------------------
 
-DISCOVERY_PORT = 7071
+# Discovery port can be overridden so a development server can run on the same
+# LAN as production without the two stealing each other's clients. Defaults to
+# the production port when MDM_DISCOVERY_PORT is unset.
+DISCOVERY_PORT = int(os.environ.get("MDM_DISCOVERY_PORT", "7071"))
 DISCOVERY_REQUEST = b"STYLYMDM_DISCOVER"
 
 
@@ -771,7 +775,10 @@ def get_local_ip_addresses() -> list[str]:
 
 
 async def run_server():
-    port = 7070
+    # WebSocket port is overridable (MDM_WS_PORT) so a development server can run
+    # alongside production on the same machine; the discovery response advertises
+    # this port, so clients follow it automatically.
+    port = int(os.environ.get("MDM_WS_PORT", "7070"))
     app = create_app()
     ip_addresses = get_local_ip_addresses()
 


### PR DESCRIPTION
## Summary

Lets a development mdm-server + APK run on the **same LAN** as production without the two stealing each other's clients. Isolation is done purely by **UDP discovery port** — production ports and behavior are unchanged when no env/flavor override is used.

| Environment | Discovery | WebSocket | Client build (label) |
|---|---|---|---|
| Production (default) | 7071 | 7070 | `prod` flavor — "STYLY-MDM Client" |
| Development (`dev` flavor) | 7081 | 7080 | `dev` flavor — "STYLY-MDM Dev" |

Both flavors share the applicationId `com.styly.mdmclient`, so they **cannot be installed at the same time** — installing the dev build replaces the production build on a device. Use a dedicated test device (or accept the replacement while testing). This keeps a device to a single STYLY-MDM controller and avoids startup-app / auto-boot / device-owner conflicts; environment isolation is entirely by port.

## Changes

**Server**
- `server.py`: discovery/ws ports read from `MDM_DISCOVERY_PORT` / `MDM_WS_PORT` (default 7071 / 7070, so production is unchanged).
- `run.sh` (new): `./run.sh [prod|dev]` wrapper; `dev` sets the dev ports.

**Client (Android)**
- `prod` / `dev` product flavors. `dev` keeps the production applicationId (no suffix) and only adds `versionNameSuffix "-dev"` and label "STYLY-MDM Dev", so installing it replaces the production build rather than coexisting with it.
- Discovery port and ws fallback port come from per-flavor `BuildConfig` fields (`DISCOVERY_PORT`, `DEFAULT_WS_PORT`); `ServerDiscovery` / `WebSocketManager` / `SettingsActivity` read them.
- The fallback URL is now flavor-aware too, so a dev build cannot accidentally connect to a production server even if discovery times out.

**CI / tooling / docs**
- `release.yml`: `assembleProdRelease` + APK path `apk/prod/release` (flavors changed the output layout).
- `build.sh`: `./build.sh [debug|release] [prod|dev]`.
- `DEVELOPMENT.md`: documents the dev-alongside-prod workflow.

## Verification
- `assembleDevDebug` / `assembleProdDebug` / `assembleProdRelease` all build successfully.
- BuildConfig: prod 7071/7070, dev 7081/7080. `aapt` badging: prod `STYLY-MDM Client` and dev `STYLY-MDM Dev` (`0.1.1-dev`) **both** package `com.styly.mdmclient`.
- Server: defaults 7071/7070 when env unset; 7081/7080 with env set.
- prod release APK lands at `apk/prod/release/…` (matches the updated CI path).

## Note
Because dev and prod share an applicationId, a device only ever has one STYLY-MDM install, so there is no dev-vs-prod device-owner conflict on a single device. Updating a device-owner production install in place with a dev build of the **same signing key** keeps device-owner status; a differently signed dev build (e.g. debug over a release install) must be uninstalled first — which clears device-owner status — so you would need to re-provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
