### PR TITLE
fix: ignore IME composition Enter in Manage Groups inputs (#33)

### DIFF
--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -991,6 +991,7 @@
       // Targets label-edit keyboard
       targetsBody.addEventListener('keydown', function (e) {
         if (!e.target.matches('[data-label-input]')) return;
+        if (e.isComposing || e.keyCode === 229) return; // ignore IME composition-confirming keys
         if (e.key === 'Enter') { e.preventDefault(); commitLabel(editingLabelId); }
         else if (e.key === 'Escape') { e.preventDefault(); editingLabelId = null; render(); }
       });
@@ -1060,6 +1061,7 @@
         if (e.target.matches('[data-mg-search]')) { manageSearch = e.target.value; refreshMgDevList(); }
       });
       manageView.addEventListener('keydown', function (e) {
+        if (e.isComposing || e.keyCode === 229) return; // ignore IME composition-confirming keys
         if (e.target.matches('[data-mg-new]') && e.key === 'Enter') {
           e.preventDefault();
           const name = e.target.value.trim(); if (name) { sendCreateGroup(name); pendingSelectGroup = name; e.target.value = ''; }


### PR DESCRIPTION
## Summary

In the **Manage Groups** view, pressing **Enter to confirm an IME conversion**
(e.g. Japanese/Chinese kanji conversion) was captured as "confirm the name",
submitting the half-composed string as the group name or device label before
the user finished composing.

The `keydown` handlers checked `e.key === 'Enter'` without guarding against
active IME composition, so the composition-confirming Enter also triggered
submission.

## Change

Add an IME guard at the top of the affected handlers:

```js
if (e.isComposing || e.keyCode === 229) return; // ignore IME composition-confirming keys
```

so only a real, post-composition Enter commits. Covers all three inputs:

- new-group input (`[data-mg-new]`)
- group rename input (`[data-mg-rename]`)
- inline device-label edit input (`[data-label-input]`)

## Verification

Drove the actual served `index.html` handlers in headless Chromium
(Playwright) with synthetic `keydown` events:

| Input | IME Enter (isComposing) | Real Enter |
|---|---|---|
| new-group | value kept, not committed ✅ | value cleared, committed ✅ |
| rename | not treated as confirm ✅ | treated as confirm ✅ |
| label edit | not treated as confirm ✅ | treated as confirm ✅ |

Negative control: with the guard removed, the IME-Enter cases regress to
committing (bug reproduced), confirming the test actually detects the defect.

## Acceptance Criteria

- [x] Enter confirming an IME conversion does not create/rename a group.
- [x] Enter with no active composition still creates/renames as before.
- [x] Applies to new-group, rename, and device-label edit inputs.

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)