### PR TITLE
feat: push files/folders to a device directory, with sync as a separate action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ STYLY-MDM currently supports PICO devices (PICO OS with Business Mode). Support 
 - **Boot persistence** — the MDM client starts automatically on HMD boot via `BOOT_COMPLETED` and PICO auto-boot intents
 - **Activity log** — every launch command and result is shown in the web console with timestamps
 - **APK deployment** — upload an APK from the web console and install it silently on selected online devices
+- **File/folder push (sync)** — upload a file or an entire folder and mirror it into a directory on selected devices; the destination is synced to match (new files added, changed files overwritten, extras removed). Destinations are limited to shared storage (`/sdcard`)
 - **Auto-terminate on switch** — the current foreground app is force-stopped before launching a new one, preventing resource conflicts
 - **Server discovery** — devices can automatically find the MDM server on the LAN via UDP broadcast (port 7071), eliminating manual URL entry
 - **IP address display** — the server logs its LAN IP addresses on startup so you know exactly where to connect

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ STYLY-MDM currently supports PICO devices (PICO OS with Business Mode). Support 
 - **Boot persistence** — the MDM client starts automatically on HMD boot via `BOOT_COMPLETED` and PICO auto-boot intents
 - **Activity log** — every launch command and result is shown in the web console with timestamps
 - **APK deployment** — upload an APK from the web console and install it silently on selected online devices
-- **File/folder push (sync)** — upload a file or an entire folder and mirror it into a directory on selected devices; the destination is synced to match (new files added, changed files overwritten, extras removed). Destinations are limited to shared storage (`/sdcard`)
+- **File/folder push** — upload a file or an entire folder and copy it into a directory on selected devices; existing files of the same name are overwritten, nothing else at the destination is touched
+- **Folder sync** — mirror a folder into a directory on selected devices, so the destination matches it exactly (new files added, changed files overwritten, **extras removed**). Requires an explicit confirmation, since it deletes. Both actions are limited to shared storage (`/sdcard`)
 - **Auto-terminate on switch** — the current foreground app is force-stopped before launching a new one, preventing resource conflicts
 - **Server discovery** — devices can automatically find the MDM server on the LAN via UDP broadcast (port 7071), eliminating manual URL entry
 - **IP address display** — the server logs its LAN IP addresses on startup so you know exactly where to connect

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -263,7 +263,7 @@ STYLY-MDM/
 
 > **Per-device install state.** `INSTALL_PROGRESS` carries only aggregate counts,
 > which cannot be mapped back to rows, so the server also broadcasts
-> `INSTALL_DEVICE_STATE` as each device moves. The console's INSTALL column shows
+> `INSTALL_DEVICE_STATE` as each device moves. The console's PROGRESS column shows
 > `Waiting…` → `Transferring…` → `Installing…` → `✓ installed` / `✗ failed`, which
 > is what distinguishes a device queued behind a transfer slot from one that is
 > genuinely installing.
@@ -308,6 +308,15 @@ STYLY-MDM/
 > `Podcasts`, `Ringtones`) so a mistyped path cannot wipe unrelated user/media
 > data. The console additionally requires an explicit "extras will be deleted"
 > confirmation before dispatch.
+>
+> Push reuses the per-device PROGRESS column, showing `Pushing…` → `✓ pushed`
+> (with the `+added ~updated -deleted` summary) / `✗ failed`. Unlike install,
+> these transitions are **not** server-driven: push is not throttled, so the
+> server holds no per-device state to broadcast. The console paints `Pushing…`
+> optimistically on dispatch and resolves it on `PUSH_FILES_RESULT`; a device that
+> drops offline mid-push clears its cell on the next `DEVICE_LIST`. The column
+> holds one state per device, so a push and an install targeting the same device
+> overwrite each other's cell — the last job dispatched wins.
 
 ## Server Discovery Protocol
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -169,7 +169,7 @@ STYLY-MDM/
 | `LAUNCH_RESULT` | Result of an app launch. Fields: `status` (`success`/`fail`), `package_name`, `error` (optional) |
 | `INSTALL_RESULT` | Result of an APK install. Fields: `status` (`success`/`fail`), `apk_filename`, `result_code` (optional), `error` (optional) |
 | `DOWNLOAD_COMPLETE` | Sent right after the APK download finishes (before the local install). Frees the server's transfer slot so the next queued device can start downloading. Fields: `apk_filename`. Optional — see the install-throttling note below. |
-| `PUSH_FILES_RESULT` | Result of a file/folder sync. Fields: `status` (`success`/`fail`), `dest_path`, `added`, `updated`, `deleted` (counts), `error` (optional) |
+| `PUSH_FILES_RESULT` | Result of a push or sync. Fields: `status` (`success`/`fail`), `dest_path`, `added`, `updated`, `deleted` (counts; `deleted` is always 0 for a push), `error` (optional) |
 
 ### Server → Device
 
@@ -177,7 +177,7 @@ STYLY-MDM/
 |---|---|
 | `EXECUTE_LAUNCH` | Launch an app. Fields: `package_name`, `extra` |
 | `EXECUTE_INSTALL` | Download and install an APK. Fields: `apk_url`, `apk_filename` |
-| `EXECUTE_PUSH_FILES` | Download a bundle and full-mirror it into a directory. Fields: `bundle_url`, `bundle_filename`, `dest_path` |
+| `EXECUTE_PUSH_FILES` | Download a bundle and apply it to a directory. Fields: `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean; `false` = copy/overwrite only, `true` = full mirror. Read with a `false` default — a missing field must never delete) |
 
 ### Admin → Server
 
@@ -185,7 +185,7 @@ STYLY-MDM/
 |---|---|
 | `LAUNCH_APP` | Launch an app on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `package_name`, `extra_data` |
 | `INSTALL_APK` | Install an uploaded APK on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `apk_url`, `apk_filename` |
-| `PUSH_FILES` | Full-mirror a bundle into a directory on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `bundle_url`, `bundle_filename`, `dest_path` |
+| `PUSH_FILES` | Apply a bundle to a directory on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean, optional; only a literal `true` requests a full mirror) |
 | `GET_DEVICE_LIST` | Request the current device list |
 | `CREATE_GROUP` | Create a new, empty device group. Fields: `name` |
 | `RENAME_GROUP` | Rename a group, preserving its members. Fields: `name`, `new_name` |
@@ -211,8 +211,8 @@ STYLY-MDM/
 | `INSTALL_SENT` | Confirmation that an install job was accepted (dispatch is throttled and runs in the background). Fields: `apk_filename`, `apk_url`, `target_count`, `max_concurrent` |
 | `INSTALL_PROGRESS` | Live progress of a throttled install job, broadcast on each transfer-slot transition. Fields: `apk_filename`, `apk_url`, `total`, `queued`, `transferring`, `transferred`, `failed`, `done` (boolean, `true` on the final update) |
 | `INSTALL_DEVICE_STATE` | Per-device companion to `INSTALL_PROGRESS`: names the devices that just entered a state, so the console can label each row instead of showing the whole target set as installing. Fields: `device_ids` (array), `state` (`queued` / `transferring` / `installing` / `fail`), `apk_filename`, `detail` (failure reason, may be empty) |
-| `PUSH_FILES_SENT` | Confirmation that push-files commands were dispatched. Fields: `bundle_filename`, `dest_path`, `sent_count`, `target_count` |
-| `PUSH_FILES_RESULT` | Forwarded file/folder sync result from a device (adds `device_id`) |
+| `PUSH_FILES_SENT` | Confirmation that push-files commands were dispatched. Fields: `bundle_filename`, `dest_path`, `delete_extras`, `sent_count`, `target_count` |
+| `PUSH_FILES_RESULT` | Forwarded file/folder result from a device (adds `device_id`) |
 | `LAUNCH_RESULT` | Forwarded result from a device |
 | `INSTALL_RESULT` | Forwarded install result from a device |
 | `GROUP_LIST` | Current device groups. Fields: `groups` (object mapping group name → array of member serials). The console derives each device's group membership from this; sent on connect and after any group change. |
@@ -287,36 +287,53 @@ STYLY-MDM/
 > so a `DOWNLOAD_COMPLETE` arriving after a transfer already timed out cannot
 > resurrect `installing` on a device the job has written off.
 
-> **Push files (file/folder sync).** The console uploads a file or a whole folder
-> to `POST /api/bundles`; the server reconstructs the tree and zips it into a
-> single bundle served from `/bundles/`. `PUSH_FILES` carries the bundle URL and a
-> destination directory; the client downloads the bundle, unzips it (with a
-> zip-slip guard), and **full-mirrors** it into the destination — new files are
-> created, changed files overwritten, and anything at the destination *not* in the
-> bundle is deleted (including now-empty directories), so the destination ends up
-> identical to the bundle (`rsync --delete` semantics). Each device reports
-> `PUSH_FILES_RESULT` with `added`/`updated`/`deleted` counts.
+> **Push files: two actions, one transport.** The console uploads a file or a whole
+> folder to `POST /api/bundles`; the server reconstructs the tree and zips it into a
+> single bundle served from `/bundles/`. `PUSH_FILES` carries the bundle URL, a
+> destination directory, and `delete_extras`. The client downloads the bundle, unzips
+> it (with a zip-slip guard), and applies it to the destination — how it applies is
+> the whole distinction:
 >
-> Because full-mirror sync deletes, and because the PICO ToBService exposes **no
-> privileged file-copy API**, two constraints apply and are enforced on both the
+> | Console action | `delete_extras` | Semantics |
+> |---|---|---|
+> | **Push Files** (file or folder) | `false` | Copy and overwrite. Nothing at the destination is removed; `deleted` is always 0. |
+> | **Sync Folder** (folder only) | `true` | Full mirror: extras at the destination — including now-empty directories — are deleted, so it ends up identical to the bundle (`rsync --delete` semantics). |
+>
+> These are two console panels rather than one panel with a delete toggle so the
+> destructive operation has to be chosen **by name**. Only Sync Folder shows the
+> warning and requires the "extras will be deleted" confirmation.
+>
+> The delete lives in exactly one place: `BundleSync.apply` in the client, gated on
+> `deleteExtras`. Everything else — the server's `handle_push_files`, the bundle
+> build — is identical for both actions and merely passes the flag through. That flag
+> is decoded defensively at both boundaries: the server treats only a literal `true`
+> as a delete request (`data.get("delete_extras") is True`), and the client reads it
+> with `optBoolean(..., false)`. **A missing or malformed field can only ever copy.**
+> Since the delete is client-side, the non-destructive Push only exists on devices
+> running an APK that has this change — an older client mirrors whatever it is sent.
+> `BundleSync` is deliberately Android-free so `app/src/test/.../BundleSyncTest.kt`
+> can prove both branches on the host JVM (`./gradlew :app:testProdDebugUnitTest`).
+>
+> Because a mirror deletes, and because the PICO ToBService exposes **no privileged
+> file-copy API**, two constraints apply to both actions and are enforced on the
 > server (syntactic) and the client (canonical): the destination must live under
 > **shared/primary external storage** (`/sdcard` · `/storage/emulated/0`) — the
 > client can only reach shared storage with `java.io.File` I/O, so app-scoped
 > `Android/data/<pkg>/` directories are *not* targetable — and it must be neither
 > the storage root nor a protected top-level directory (`Android`, `Download(s)`,
 > `DCIM`, `Pictures`, `Movies`, `Music`, `Documents`, `Alarms`, `Notifications`,
-> `Podcasts`, `Ringtones`) so a mistyped path cannot wipe unrelated user/media
-> data. The console additionally requires an explicit "extras will be deleted"
-> confirmation before dispatch.
+> `Podcasts`, `Ringtones`) so a mistyped path cannot wipe unrelated user/media data.
 >
-> Push reuses the per-device PROGRESS column, showing `Pushing…` → `✓ pushed`
-> (with the `+added ~updated -deleted` summary) / `✗ failed`. Unlike install,
-> these transitions are **not** server-driven: push is not throttled, so the
-> server holds no per-device state to broadcast. The console paints `Pushing…`
-> optimistically on dispatch and resolves it on `PUSH_FILES_RESULT`; a device that
-> drops offline mid-push clears its cell on the next `DEVICE_LIST`. The column
-> holds one state per device, so a push and an install targeting the same device
-> overwrite each other's cell — the last job dispatched wins.
+> Both actions reuse the per-device PROGRESS column, showing `Pushing…` / `Syncing…`
+> → `✓ pushed` / `✓ synced` (with the `+added ~updated -deleted` summary) / `✗ failed`.
+> Unlike install, these transitions are **not** server-driven: neither action is
+> throttled, so the server holds no per-device state to broadcast. The console paints
+> the in-flight state optimistically on dispatch and resolves it on
+> `PUSH_FILES_RESULT`; a device that drops offline mid-job clears its cell on the next
+> `DEVICE_LIST`. `PUSH_FILES_RESULT` does not name the mode, so the console carries the
+> verb over from what it dispatched (a page reloaded mid-job falls back to "pushed").
+> The column holds one state per device, so a push and an install targeting the same
+> device overwrite each other's cell — the last job dispatched wins.
 
 ## Server Discovery Protocol
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -199,7 +199,7 @@ STYLY-MDM/
 |---|---|
 | `POST /api/apks` | Multipart upload with field `apk`. Returns `apk_url`, `apk_filename`, and `size`. |
 | `GET /apks/{filename}` | Serves uploaded APK files to devices on the LAN. |
-| `POST /api/bundles` | Multipart upload with repeated field `files`; each part's filename carries its folder-relative path. The server zips the reconstructed tree into a bundle. Returns `bundle_url`, `bundle_filename`, `size`, and `entry_count`. |
+| `POST /api/bundles` | Multipart upload with repeated field `files`; each part's filename carries its folder-relative path. The server zips the reconstructed tree into a bundle, excluding OS metadata (`.DS_Store`, `._*`, `Thumbs.db`, …). Returns `bundle_url`, `bundle_filename`, `size`, `entry_count` (files in the bundle), and `skipped_count` (files excluded). 400 if every uploaded file was excluded. |
 | `GET /bundles/{filename}` | Serves generated file/folder bundles (zip) to devices on the LAN. |
 
 ### Server → Admin
@@ -289,7 +289,8 @@ STYLY-MDM/
 
 > **Push files: two actions, one transport.** The console uploads a file or a whole
 > folder to `POST /api/bundles`; the server reconstructs the tree and zips it into a
-> single bundle served from `/bundles/`. `PUSH_FILES` carries the bundle URL, a
+> single bundle served from `/bundles/`, dropping OS-generated metadata on the way in
+> (see below). `PUSH_FILES` carries the bundle URL, a
 > destination directory, and `delete_extras`. The client downloads the bundle, unzips
 > it (with a zip-slip guard), and applies it to the destination — how it applies is
 > the whole distinction:
@@ -313,6 +314,23 @@ STYLY-MDM/
 > running an APK that has this change — an older client mirrors whatever it is sent.
 > `BundleSync` is deliberately Android-free so `app/src/test/.../BundleSyncTest.kt`
 > can prove both branches on the host JVM (`./gradlew :app:testProdDebugUnitTest`).
+>
+> **Excluded from every bundle.** A folder pick drags along whatever the OS left in it —
+> a `.DS_Store` per directory, an `._name` AppleDouble sidecar per file once the folder has
+> been through a USB stick, `Thumbs.db`, `desktop.ini`. `is_excluded_bundle_entry` drops
+> these in `upload_bundle_handler`, before anything is written to staging, so they never
+> reach the zip, never count against `MAX_BUNDLE_ENTRIES`, and never land on a device.
+> Matching is case-insensitive and applies to *any* path segment, so an excluded directory
+> (`.Spotlight-V100`, `__MACOSX`, `$RECYCLE.BIN`, `.Trash-1000`) takes its contents with it.
+>
+> The list is deliberately confined to files an OS creates on its own. `.git/`, Unity
+> `.meta` files, and dotfiles at large are uploaded as-is: silently dropping content a user
+> authored would be a worse failure than shipping an unwanted `.DS_Store`. An upload that is
+> *entirely* metadata is rejected with 400 rather than producing an empty bundle — a Sync
+> Folder given an empty bundle would wipe the destination. Since the console's pre-upload
+> file count comes from the browser and the post-upload count comes from the server, the
+> upload response returns `skipped_count` and the console logs what was excluded rather than
+> letting the two numbers silently disagree.
 >
 > Because a mirror deletes, and because the PICO ToBService exposes **no privileged
 > file-copy API**, two constraints apply to both actions and are enforced on the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -169,6 +169,7 @@ STYLY-MDM/
 | `LAUNCH_RESULT` | Result of an app launch. Fields: `status` (`success`/`fail`), `package_name`, `error` (optional) |
 | `INSTALL_RESULT` | Result of an APK install. Fields: `status` (`success`/`fail`), `apk_filename`, `result_code` (optional), `error` (optional) |
 | `DOWNLOAD_COMPLETE` | Sent right after the APK download finishes (before the local install). Frees the server's transfer slot so the next queued device can start downloading. Fields: `apk_filename`. Optional — see the install-throttling note below. |
+| `PUSH_FILES_RESULT` | Result of a file/folder sync. Fields: `status` (`success`/`fail`), `dest_path`, `added`, `updated`, `deleted` (counts), `error` (optional) |
 
 ### Server → Device
 
@@ -176,6 +177,7 @@ STYLY-MDM/
 |---|---|
 | `EXECUTE_LAUNCH` | Launch an app. Fields: `package_name`, `extra` |
 | `EXECUTE_INSTALL` | Download and install an APK. Fields: `apk_url`, `apk_filename` |
+| `EXECUTE_PUSH_FILES` | Download a bundle and full-mirror it into a directory. Fields: `bundle_url`, `bundle_filename`, `dest_path` |
 
 ### Admin → Server
 
@@ -183,6 +185,7 @@ STYLY-MDM/
 |---|---|
 | `LAUNCH_APP` | Launch an app on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `package_name`, `extra_data` |
 | `INSTALL_APK` | Install an uploaded APK on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `apk_url`, `apk_filename` |
+| `PUSH_FILES` | Full-mirror a bundle into a directory on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `bundle_url`, `bundle_filename`, `dest_path` |
 | `GET_DEVICE_LIST` | Request the current device list |
 | `CREATE_GROUP` | Create a new, empty device group. Fields: `name` |
 | `RENAME_GROUP` | Rename a group, preserving its members. Fields: `name`, `new_name` |
@@ -196,6 +199,8 @@ STYLY-MDM/
 |---|---|
 | `POST /api/apks` | Multipart upload with field `apk`. Returns `apk_url`, `apk_filename`, and `size`. |
 | `GET /apks/{filename}` | Serves uploaded APK files to devices on the LAN. |
+| `POST /api/bundles` | Multipart upload with repeated field `files`; each part's filename carries its folder-relative path. The server zips the reconstructed tree into a bundle. Returns `bundle_url`, `bundle_filename`, `size`, and `entry_count`. |
+| `GET /bundles/{filename}` | Serves generated file/folder bundles (zip) to devices on the LAN. |
 
 ### Server → Admin
 
@@ -206,6 +211,8 @@ STYLY-MDM/
 | `INSTALL_SENT` | Confirmation that an install job was accepted (dispatch is throttled and runs in the background). Fields: `apk_filename`, `apk_url`, `target_count`, `max_concurrent` |
 | `INSTALL_PROGRESS` | Live progress of a throttled install job, broadcast on each transfer-slot transition. Fields: `apk_filename`, `apk_url`, `total`, `queued`, `transferring`, `transferred`, `failed`, `done` (boolean, `true` on the final update) |
 | `INSTALL_DEVICE_STATE` | Per-device companion to `INSTALL_PROGRESS`: names the devices that just entered a state, so the console can label each row instead of showing the whole target set as installing. Fields: `device_ids` (array), `state` (`queued` / `transferring` / `installing` / `fail`), `apk_filename`, `detail` (failure reason, may be empty) |
+| `PUSH_FILES_SENT` | Confirmation that push-files commands were dispatched. Fields: `bundle_filename`, `dest_path`, `sent_count`, `target_count` |
+| `PUSH_FILES_RESULT` | Forwarded file/folder sync result from a device (adds `device_id`) |
 | `LAUNCH_RESULT` | Forwarded result from a device |
 | `INSTALL_RESULT` | Forwarded install result from a device |
 | `GROUP_LIST` | Current device groups. Fields: `groups` (object mapping group name → array of member serials). The console derives each device's group membership from this; sent on connect and after any group change. |
@@ -280,6 +287,28 @@ STYLY-MDM/
 > so a `DOWNLOAD_COMPLETE` arriving after a transfer already timed out cannot
 > resurrect `installing` on a device the job has written off.
 
+> **Push files (file/folder sync).** The console uploads a file or a whole folder
+> to `POST /api/bundles`; the server reconstructs the tree and zips it into a
+> single bundle served from `/bundles/`. `PUSH_FILES` carries the bundle URL and a
+> destination directory; the client downloads the bundle, unzips it (with a
+> zip-slip guard), and **full-mirrors** it into the destination — new files are
+> created, changed files overwritten, and anything at the destination *not* in the
+> bundle is deleted (including now-empty directories), so the destination ends up
+> identical to the bundle (`rsync --delete` semantics). Each device reports
+> `PUSH_FILES_RESULT` with `added`/`updated`/`deleted` counts.
+>
+> Because full-mirror sync deletes, and because the PICO ToBService exposes **no
+> privileged file-copy API**, two constraints apply and are enforced on both the
+> server (syntactic) and the client (canonical): the destination must live under
+> **shared/primary external storage** (`/sdcard` · `/storage/emulated/0`) — the
+> client can only reach shared storage with `java.io.File` I/O, so app-scoped
+> `Android/data/<pkg>/` directories are *not* targetable — and it must be neither
+> the storage root nor a protected top-level directory (`Android`, `Download(s)`,
+> `DCIM`, `Pictures`, `Movies`, `Music`, `Documents`, `Alarms`, `Notifications`,
+> `Podcasts`, `Ringtones`) so a mistyped path cannot wipe unrelated user/media
+> data. The console additionally requires an explicit "extras will be deleted"
+> confirmation before dispatch.
+
 ## Server Discovery Protocol
 
 STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.
@@ -327,7 +356,7 @@ The MDM client requires the following Android permissions:
 | `RECEIVE_BOOT_COMPLETED` | Auto-start on device boot |
 | `ACCESS_NETWORK_STATE` | Monitor network connectivity |
 | `ACCESS_WIFI_STATE` | Retrieve the device IP address |
-| `MANAGE_EXTERNAL_STORAGE` | Write downloaded APKs to shared storage so the PICO ToBService can read them for silent install |
+| `MANAGE_EXTERNAL_STORAGE` | Write downloaded APKs to shared storage so the PICO ToBService can read them for silent install, and read/write shared-storage directories for file/folder push (sync) |
 
 Battery percentage and charging state are read with Android's standard battery
 status APIs (`ACTION_BATTERY_CHANGED` / `BatteryManager`), which do not require

--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -79,4 +79,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.picoxr.tobservice:tobservicelib:4.3.16'
+
+    // Host JVM tests. BundleSync deletes files on the device, so its copy-vs-mirror
+    // behaviour is proven here rather than only on real hardware.
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/BundleSync.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/BundleSync.kt
@@ -1,0 +1,81 @@
+package com.styly.mdmclient
+
+import java.io.File
+
+data class SyncResult(val added: Int, val updated: Int, val deleted: Int)
+
+/**
+ * Applies a downloaded, unzipped bundle tree onto a destination directory.
+ *
+ * Deliberately free of Android dependencies (plain `java.io.File` I/O) so the destructive
+ * branch can be exercised by host JVM unit tests rather than only on a real device.
+ */
+object BundleSync {
+
+    /**
+     * Copy every staged file into [destDir], overwriting existing files.
+     *
+     * When [deleteExtras] is false (push): nothing at the destination is removed, so files
+     * already there that are absent from the bundle survive untouched. `deleted` is 0.
+     *
+     * When [deleteExtras] is true (sync): the destination is additionally pruned of anything
+     * not present in the bundle — including now-empty directories — so it ends up identical
+     * to the bundle (`rsync --delete` semantics).
+     *
+     * [deleteExtras] has no default on purpose: deleting is destructive enough that every
+     * call site must name its intent. The safe default lives at the protocol boundary, where
+     * a missing `delete_extras` field decodes to false.
+     */
+    fun apply(staging: File, destDir: File, deleteExtras: Boolean): SyncResult {
+        if (!destDir.exists() && !destDir.mkdirs()) {
+            throw IllegalStateException("Failed to create destination directory: ${destDir.absolutePath}")
+        }
+
+        var added = 0
+        var updated = 0
+        staging.walkTopDown().forEach { src ->
+            if (src == staging || src.isDirectory) return@forEach
+            val rel = src.relativeTo(staging).path
+            val target = File(destDir, rel)
+            val existed = target.isFile
+            target.parentFile?.mkdirs()
+            src.copyTo(target, overwrite = true)
+            if (existed) updated++ else added++
+        }
+
+        if (!deleteExtras) {
+            return SyncResult(added, updated, 0)
+        }
+
+        val stagedFiles = HashSet<String>()
+        val stagedDirs = HashSet<String>()
+        staging.walkTopDown().forEach { f ->
+            if (f == staging) return@forEach
+            val rel = f.relativeTo(staging).path.replace(File.separatorChar, '/')
+            if (f.isDirectory) {
+                stagedDirs.add(rel)
+            } else {
+                stagedFiles.add(rel)
+                // Keep every ancestor directory of a staged file.
+                var parent = File(rel).parent
+                while (parent != null) {
+                    stagedDirs.add(parent.replace(File.separatorChar, '/'))
+                    parent = File(parent).parent
+                }
+            }
+        }
+
+        // Prune extras bottom-up: files first, then dirs (empty by the time we reach them).
+        var deleted = 0
+        destDir.walkBottomUp().forEach { entry ->
+            if (entry == destDir) return@forEach
+            val rel = entry.relativeTo(destDir).path.replace(File.separatorChar, '/')
+            if (entry.isFile) {
+                if (rel !in stagedFiles && entry.delete()) deleted++
+            } else if (rel !in stagedDirs) {
+                entry.delete()
+            }
+        }
+        return SyncResult(added, updated, deleted)
+    }
+}

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -301,15 +301,20 @@ class MdmClientService : Service() {
     }
 
     /**
-     * Download a file/folder bundle and full-mirror it into a destination directory: new
-     * files are created, changed files overwritten, and anything at the destination not in
-     * the bundle is deleted (incl. now-empty dirs), so the destination ends up identical to
-     * the bundle. Destinations are limited to shared storage — the PICO ToBService has no
-     * privileged file-copy API, so only /sdcard is reachable via java.io.File I/O.
+     * Download a file/folder bundle and apply it to a destination directory.
+     *
+     * `delete_extras` picks the semantics: absent or false means push (copy and overwrite,
+     * never delete); true means sync (full mirror, pruning anything at the destination that
+     * is not in the bundle). It is read with a false default so a payload from a server that
+     * predates the flag can only ever copy — a missing field must never delete.
+     *
+     * Destinations are limited to shared storage — the PICO ToBService has no privileged
+     * file-copy API, so only /sdcard is reachable via java.io.File I/O.
      */
     private fun executePushFiles(payload: JSONObject) {
         val bundleUrl = payload.optString("bundle_url", "")
         val destPath = payload.optString("dest_path", "").trim()
+        val deleteExtras = payload.optBoolean("delete_extras", false)
 
         if (bundleUrl.isEmpty()) {
             Log.e(TAG, "EXECUTE_PUSH_FILES missing bundle_url")
@@ -340,10 +345,11 @@ class MdmClientService : Service() {
                 Log.i(TAG, "Downloading bundle: $bundleUrl")
                 bundleFile = downloadBundle(bundleUrl)
                 staging = unzipToStaging(bundleFile)
-                val result = mirrorStagingToDest(staging, File(destPath))
+                val result = BundleSync.apply(staging, File(destPath), deleteExtras)
                 Log.i(
                     TAG,
-                    "Push-files sync to $destPath: +${result.added} ~${result.updated} -${result.deleted}"
+                    "Push-files ${if (deleteExtras) "sync" else "copy"} to $destPath: " +
+                        "+${result.added} ~${result.updated} -${result.deleted}"
                 )
                 sendPushFilesResult(
                     destPath, "success", result.added, result.updated, result.deleted, ""
@@ -433,59 +439,6 @@ class MdmClientService : Service() {
         return staging
     }
 
-    /**
-     * Full-mirror the staging tree into destDir: copy every staged file (overwrite), then
-     * delete anything under destDir not present in the bundle so destDir == bundle exactly.
-     */
-    private fun mirrorStagingToDest(staging: File, destDir: File): SyncResult {
-        val stagedFiles = HashSet<String>()
-        val stagedDirs = HashSet<String>()
-        staging.walkTopDown().forEach { f ->
-            if (f == staging) return@forEach
-            val rel = f.relativeTo(staging).path.replace(File.separatorChar, '/')
-            if (f.isDirectory) {
-                stagedDirs.add(rel)
-            } else {
-                stagedFiles.add(rel)
-                // Keep every ancestor directory of a staged file.
-                var parent = File(rel).parent
-                while (parent != null) {
-                    stagedDirs.add(parent.replace(File.separatorChar, '/'))
-                    parent = File(parent).parent
-                }
-            }
-        }
-
-        if (!destDir.exists() && !destDir.mkdirs()) {
-            throw IllegalStateException("Failed to create destination directory: ${destDir.absolutePath}")
-        }
-
-        var added = 0
-        var updated = 0
-        staging.walkTopDown().forEach { src ->
-            if (src == staging || src.isDirectory) return@forEach
-            val rel = src.relativeTo(staging).path
-            val target = File(destDir, rel)
-            val existed = target.isFile
-            target.parentFile?.mkdirs()
-            src.copyTo(target, overwrite = true)
-            if (existed) updated++ else added++
-        }
-
-        // Prune extras bottom-up: files first, then dirs (empty by the time we reach them).
-        var deleted = 0
-        destDir.walkBottomUp().forEach { entry ->
-            if (entry == destDir) return@forEach
-            val rel = entry.relativeTo(destDir).path.replace(File.separatorChar, '/')
-            if (entry.isFile) {
-                if (rel !in stagedFiles && entry.delete()) deleted++
-            } else if (rel !in stagedDirs) {
-                entry.delete()
-            }
-        }
-        return SyncResult(added, updated, deleted)
-    }
-
     private fun pushTempDir(): File {
         val downloadsRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val dir = File(downloadsRoot, "styly-mdm/.push-tmp")
@@ -496,10 +449,11 @@ class MdmClientService : Service() {
     }
 
     /**
-     * Validate a device destination path for full-mirror sync. Because sync deletes extras,
-     * a bad path could wipe unrelated data — so the canonical path must live under shared
-     * storage and be neither the storage root nor a protected top-level directory. Returns an
-     * error message, or null if the path is safe.
+     * Validate a device destination path. Applied to pushes as well as syncs: a sync deletes
+     * extras, so a bad path could wipe unrelated data, and holding both to the same rule keeps
+     * a push from quietly reaching somewhere a sync may not. The canonical path must live under
+     * shared storage and be neither the storage root nor a protected top-level directory.
+     * Returns an error message, or null if the path is safe.
      */
     private fun validateDestPath(destPath: String): String? {
         if (destPath.isEmpty()) return "Destination path is required"
@@ -526,7 +480,6 @@ class MdmClientService : Service() {
         return null
     }
 
-    private data class SyncResult(val added: Int, val updated: Int, val deleted: Int)
 
     private fun sendPushFilesResult(
         destPath: String,

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.zip.ZipFile
 
 /**
  * Foreground service that maintains the WebSocket connection to the STYLY-MDM server
@@ -35,6 +36,14 @@ class MdmClientService : Service() {
         const val ACTION_STATUS_UPDATE = "com.styly.mdmclient.STATUS_UPDATE"
         const val EXTRA_CONNECTED = "connected"
         const val EXTRA_MESSAGE = "message"
+
+        // Top-level shared-storage directories that full-mirror push-files sync must never
+        // target: mirroring into them would delete unrelated user/media/app data. Matched
+        // (case-insensitively) against the first path segment below the storage root.
+        private val PROTECTED_TOPLEVEL_DIRS = setOf(
+            "android", "download", "downloads", "dcim", "pictures", "movies", "music",
+            "documents", "alarms", "notifications", "podcasts", "ringtones"
+        )
     }
 
     private lateinit var webSocketManager: WebSocketManager
@@ -74,6 +83,7 @@ class MdmClientService : Service() {
         when (type) {
             "EXECUTE_LAUNCH" -> executeLaunch(payload)
             "EXECUTE_INSTALL" -> executeInstall(payload)
+            "EXECUTE_PUSH_FILES" -> executePushFiles(payload)
             "SET_STARTUP_APP" -> handleSetStartupApp(payload)
             "CLEAR_STARTUP_APP" -> handleClearStartupApp()
             else -> Log.w(TAG, "Unknown command type: $type")
@@ -288,6 +298,256 @@ class MdmClientService : Service() {
             apkFile.delete()
             throw e
         }
+    }
+
+    /**
+     * Download a file/folder bundle and full-mirror it into a destination directory: new
+     * files are created, changed files overwritten, and anything at the destination not in
+     * the bundle is deleted (incl. now-empty dirs), so the destination ends up identical to
+     * the bundle. Destinations are limited to shared storage — the PICO ToBService has no
+     * privileged file-copy API, so only /sdcard is reachable via java.io.File I/O.
+     */
+    private fun executePushFiles(payload: JSONObject) {
+        val bundleUrl = payload.optString("bundle_url", "")
+        val destPath = payload.optString("dest_path", "").trim()
+
+        if (bundleUrl.isEmpty()) {
+            Log.e(TAG, "EXECUTE_PUSH_FILES missing bundle_url")
+            sendPushFilesResult(destPath, "fail", 0, 0, 0, "Missing bundle_url")
+            return
+        }
+
+        val destError = validateDestPath(destPath)
+        if (destError != null) {
+            Log.e(TAG, "EXECUTE_PUSH_FILES rejected destination '$destPath': $destError")
+            sendPushFilesResult(destPath, "fail", 0, 0, 0, destError)
+            return
+        }
+
+        if (!hasExternalStorageAccess()) {
+            Log.e(TAG, "MANAGE_EXTERNAL_STORAGE not granted; cannot sync files")
+            sendPushFilesResult(
+                destPath, "fail", 0, 0, 0,
+                "All files access (MANAGE_EXTERNAL_STORAGE) is not granted on this device"
+            )
+            return
+        }
+
+        Thread {
+            var bundleFile: File? = null
+            var staging: File? = null
+            try {
+                Log.i(TAG, "Downloading bundle: $bundleUrl")
+                bundleFile = downloadBundle(bundleUrl)
+                staging = unzipToStaging(bundleFile)
+                val result = mirrorStagingToDest(staging, File(destPath))
+                Log.i(
+                    TAG,
+                    "Push-files sync to $destPath: +${result.added} ~${result.updated} -${result.deleted}"
+                )
+                sendPushFilesResult(
+                    destPath, "success", result.added, result.updated, result.deleted, ""
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to push files to $destPath", e)
+                sendPushFilesResult(destPath, "fail", 0, 0, 0, e.message ?: "Unknown error")
+            } finally {
+                bundleFile?.delete()
+                staging?.deleteRecursively()
+            }
+        }.start()
+    }
+
+    private fun downloadBundle(bundleUrl: String): File {
+        val url = URL(bundleUrl)
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            connectTimeout = 15_000
+            readTimeout = 120_000
+            requestMethod = "GET"
+            instanceFollowRedirects = true
+        }
+
+        try {
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                throw IllegalStateException("Bundle download failed with HTTP $responseCode")
+            }
+
+            val outputFile = File(pushTempDir(), "${System.currentTimeMillis()}-bundle.zip")
+            var bytesReadTotal = 0L
+            connection.inputStream.use { input ->
+                FileOutputStream(outputFile).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read == -1) break
+                        output.write(buffer, 0, read)
+                        bytesReadTotal += read
+                    }
+                }
+            }
+
+            if (bytesReadTotal == 0L) {
+                outputFile.delete()
+                throw IllegalStateException("Downloaded bundle is empty")
+            }
+
+            Log.i(TAG, "Downloaded bundle to ${outputFile.absolutePath} ($bytesReadTotal bytes)")
+            return outputFile
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    /**
+     * Unzip a bundle into a fresh staging directory, rejecting any entry whose path would
+     * escape the staging root (zip-slip guard).
+     */
+    private fun unzipToStaging(bundleFile: File): File {
+        val staging = File(pushTempDir(), "staging-${System.currentTimeMillis()}")
+        if (!staging.mkdirs()) {
+            throw IllegalStateException("Failed to create staging directory")
+        }
+
+        val stagingRoot = staging.canonicalPath
+        val stagingPrefix = stagingRoot + File.separator
+        ZipFile(bundleFile).use { zip ->
+            val entries = zip.entries()
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                val outFile = File(staging, entry.name)
+                val outCanonical = outFile.canonicalPath
+                if (outCanonical != stagingRoot && !outCanonical.startsWith(stagingPrefix)) {
+                    throw IllegalStateException("Zip entry escapes staging dir: ${entry.name}")
+                }
+                if (entry.isDirectory) {
+                    outFile.mkdirs()
+                } else {
+                    outFile.parentFile?.mkdirs()
+                    zip.getInputStream(entry).use { input ->
+                        FileOutputStream(outFile).use { output -> input.copyTo(output) }
+                    }
+                }
+            }
+        }
+        return staging
+    }
+
+    /**
+     * Full-mirror the staging tree into destDir: copy every staged file (overwrite), then
+     * delete anything under destDir not present in the bundle so destDir == bundle exactly.
+     */
+    private fun mirrorStagingToDest(staging: File, destDir: File): SyncResult {
+        val stagedFiles = HashSet<String>()
+        val stagedDirs = HashSet<String>()
+        staging.walkTopDown().forEach { f ->
+            if (f == staging) return@forEach
+            val rel = f.relativeTo(staging).path.replace(File.separatorChar, '/')
+            if (f.isDirectory) {
+                stagedDirs.add(rel)
+            } else {
+                stagedFiles.add(rel)
+                // Keep every ancestor directory of a staged file.
+                var parent = File(rel).parent
+                while (parent != null) {
+                    stagedDirs.add(parent.replace(File.separatorChar, '/'))
+                    parent = File(parent).parent
+                }
+            }
+        }
+
+        if (!destDir.exists() && !destDir.mkdirs()) {
+            throw IllegalStateException("Failed to create destination directory: ${destDir.absolutePath}")
+        }
+
+        var added = 0
+        var updated = 0
+        staging.walkTopDown().forEach { src ->
+            if (src == staging || src.isDirectory) return@forEach
+            val rel = src.relativeTo(staging).path
+            val target = File(destDir, rel)
+            val existed = target.isFile
+            target.parentFile?.mkdirs()
+            src.copyTo(target, overwrite = true)
+            if (existed) updated++ else added++
+        }
+
+        // Prune extras bottom-up: files first, then dirs (empty by the time we reach them).
+        var deleted = 0
+        destDir.walkBottomUp().forEach { entry ->
+            if (entry == destDir) return@forEach
+            val rel = entry.relativeTo(destDir).path.replace(File.separatorChar, '/')
+            if (entry.isFile) {
+                if (rel !in stagedFiles && entry.delete()) deleted++
+            } else if (rel !in stagedDirs) {
+                entry.delete()
+            }
+        }
+        return SyncResult(added, updated, deleted)
+    }
+
+    private fun pushTempDir(): File {
+        val downloadsRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val dir = File(downloadsRoot, "styly-mdm/.push-tmp")
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw IllegalStateException("Failed to create push temp directory")
+        }
+        return dir
+    }
+
+    /**
+     * Validate a device destination path for full-mirror sync. Because sync deletes extras,
+     * a bad path could wipe unrelated data — so the canonical path must live under shared
+     * storage and be neither the storage root nor a protected top-level directory. Returns an
+     * error message, or null if the path is safe.
+     */
+    private fun validateDestPath(destPath: String): String? {
+        if (destPath.isEmpty()) return "Destination path is required"
+        if (!destPath.startsWith("/")) return "Destination must be an absolute path"
+        if (destPath.split("/").contains("..")) return "Destination path must not contain '..'"
+
+        val storageRoot = Environment.getExternalStorageDirectory().canonicalFile
+        val target: File = try {
+            File(destPath).canonicalFile
+        } catch (e: Exception) {
+            return "Invalid destination path"
+        }
+        val rootPath = storageRoot.path
+        if (target.path == rootPath) {
+            return "Destination must be a subdirectory, not the shared-storage root"
+        }
+        if (!target.path.startsWith(rootPath + File.separator)) {
+            return "Destination must be under shared storage ($rootPath)"
+        }
+        val firstSegment = target.path.substring(rootPath.length + 1).split("/")[0]
+        if (firstSegment.lowercase() in PROTECTED_TOPLEVEL_DIRS) {
+            return "Destination must not be inside the protected '$firstSegment' directory"
+        }
+        return null
+    }
+
+    private data class SyncResult(val added: Int, val updated: Int, val deleted: Int)
+
+    private fun sendPushFilesResult(
+        destPath: String,
+        status: String,
+        added: Int,
+        updated: Int,
+        deleted: Int,
+        error: String
+    ) {
+        val result = JSONObject().apply {
+            put("type", "PUSH_FILES_RESULT")
+            put("status", status)
+            put("dest_path", destPath)
+            put("added", added)
+            put("updated", updated)
+            put("deleted", deleted)
+            if (error.isNotEmpty()) {
+                put("error", error)
+            }
+        }
+        webSocketManager.sendMessage(result)
     }
 
     private fun hasExternalStorageAccess(): Boolean {

--- a/mdm-client/app/src/test/java/com/styly/mdmclient/BundleSyncTest.kt
+++ b/mdm-client/app/src/test/java/com/styly/mdmclient/BundleSyncTest.kt
@@ -1,0 +1,97 @@
+package com.styly.mdmclient
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * The destructive branch of the push-files feature lives here, so it is tested on the host JVM.
+ * The central guarantee: pushing a single file into a directory must never remove what is
+ * already there. Only an explicit sync (deleteExtras = true) prunes.
+ */
+class BundleSyncTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun write(root: File, rel: String, content: String): File {
+        val f = File(root, rel)
+        f.parentFile?.mkdirs()
+        f.writeText(content)
+        return f
+    }
+
+    @Test
+    fun `push does not delete existing files at the destination`() {
+        val staging = tmp.newFolder("staging")
+        val dest = tmp.newFolder("dest")
+        write(staging, "new.txt", "new")
+        val untouched = write(dest, "keep.txt", "keep")
+        val nested = write(dest, "sub/deep.txt", "deep")
+
+        val result = BundleSync.apply(staging, dest, deleteExtras = false)
+
+        assertTrue("bundle file must be created", File(dest, "new.txt").isFile)
+        assertTrue("unrelated file must survive a push", untouched.isFile)
+        assertTrue("unrelated nested file must survive a push", nested.isFile)
+        assertEquals("keep", untouched.readText())
+        assertEquals(SyncResult(added = 1, updated = 0, deleted = 0), result)
+    }
+
+    @Test
+    fun `push overwrites a file of the same name and counts it as updated`() {
+        val staging = tmp.newFolder("staging")
+        val dest = tmp.newFolder("dest")
+        write(staging, "same.txt", "fresh")
+        write(dest, "same.txt", "stale")
+
+        val result = BundleSync.apply(staging, dest, deleteExtras = false)
+
+        assertEquals("fresh", File(dest, "same.txt").readText())
+        assertEquals(SyncResult(added = 0, updated = 1, deleted = 0), result)
+    }
+
+    @Test
+    fun `sync deletes extras and prunes emptied directories`() {
+        val staging = tmp.newFolder("staging")
+        val dest = tmp.newFolder("dest")
+        write(staging, "keep.txt", "keep")
+        write(dest, "keep.txt", "old")
+        write(dest, "extra.txt", "extra")
+        write(dest, "stale/nested.txt", "nested")
+
+        val result = BundleSync.apply(staging, dest, deleteExtras = true)
+
+        assertEquals("keep", File(dest, "keep.txt").readText())
+        assertFalse("extra file must be pruned by a sync", File(dest, "extra.txt").exists())
+        assertFalse("emptied directory must be pruned by a sync", File(dest, "stale").exists())
+        assertEquals(SyncResult(added = 0, updated = 1, deleted = 2), result)
+    }
+
+    @Test
+    fun `sync keeps directories that a bundle file lives in`() {
+        val staging = tmp.newFolder("staging")
+        val dest = tmp.newFolder("dest")
+        write(staging, "a/b/leaf.txt", "leaf")
+
+        val result = BundleSync.apply(staging, dest, deleteExtras = true)
+
+        assertTrue(File(dest, "a/b/leaf.txt").isFile)
+        assertEquals(SyncResult(added = 1, updated = 0, deleted = 0), result)
+    }
+
+    @Test
+    fun `push creates a missing destination directory`() {
+        val staging = tmp.newFolder("staging")
+        val dest = File(tmp.root, "absent")
+        write(staging, "only.txt", "x")
+
+        BundleSync.apply(staging, dest, deleteExtras = false)
+
+        assertTrue(File(dest, "only.txt").isFile)
+    }
+}

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -11,9 +11,13 @@ import json
 import logging
 import os
 import re
+import shutil
 import socket
+import tempfile
 import time
+import zipfile
 from pathlib import Path
+from urllib.parse import unquote
 from aiohttp import web
 
 logging.basicConfig(
@@ -48,6 +52,14 @@ MAX_CONCURRENT_TRANSFERS = max(1, int(os.environ.get("MDM_MAX_CONCURRENT_TRANSFE
 # recovers stuck slots sooner at the risk of releasing a slow-but-healthy transfer
 # early, which only relaxes throttling and never drops the install itself.
 TRANSFER_TIMEOUT = float(os.environ.get("MDM_TRANSFER_TIMEOUT", "600"))
+
+# Generated file/folder bundles (for the push-files sync feature) live alongside the APKs.
+# The console uploads a file or folder; the server zips it into BUNDLE_DIR and serves it to
+# devices, which mirror it into a destination directory. Kept separate from APK_DIR so the
+# APK workflow is untouched.
+BUNDLE_DIR = DATA_DIR / "bundles"
+MAX_BUNDLE_SIZE = 2 * 1024 * 1024 * 1024  # 2 GiB (total uploaded bytes before zipping)
+MAX_BUNDLE_ENTRIES = 5000  # cap files per bundle to bound tree reconstruction
 
 # Persistent per-device registry: serial -> {label, model, ip, last_seen, startup_app, battery}
 REGISTRY_PATH = DATA_DIR / "device_registry.json"
@@ -411,6 +423,145 @@ def unique_apk_path(filename: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# File/folder bundle helpers (push-files sync)
+# ---------------------------------------------------------------------------
+
+# Primary/shared external storage mount points on Android. Push-files destinations must live
+# under one of these: the PICO ToBService exposes no privileged file-copy API, so the client
+# can only reach shared storage with plain java.io.File I/O (app-scoped Android/data/<pkg>/
+# is unreadable across UIDs — the same wall the APK download documents).
+SHARED_STORAGE_PREFIXES = ("/sdcard/", "/storage/emulated/0/")
+
+# Well-known top-level directories under shared storage that full-mirror sync must never
+# target: mirroring into them would delete unrelated user/media/app data on every selected
+# device. Matched case-insensitively against the first segment below the storage root.
+PROTECTED_TOPLEVEL_DIRS = frozenset({
+    "android", "download", "downloads", "dcim", "pictures", "movies", "music",
+    "documents", "alarms", "notifications", "podcasts", "ringtones",
+})
+
+
+def sanitize_relpath(raw: str | None) -> str | None:
+    """Return a safe forward-slash relative path for a bundle entry, or None if invalid.
+
+    Rejects absolute paths, parent traversal (``..``) and NUL; drops empty/``.`` segments and
+    normalizes backslashes. Used to reconstruct an uploaded folder tree under a temp root
+    without any entry escaping it.
+    """
+    if not raw:
+        return None
+    text = raw.replace("\\", "/")
+    if "\x00" in text:
+        return None
+    parts: list[str] = []
+    for seg in text.split("/"):
+        seg = seg.strip()
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            return None
+        parts.append(seg)
+    if not parts:
+        return None
+    return "/".join(parts)
+
+
+def validate_dest_path(dest: str | None) -> str | None:
+    """Return an error message if a device destination path is unsafe, else None.
+
+    Full-mirror sync deletes anything at the destination not in the bundle, so a wrong path
+    would wipe unrelated data on every selected device. The path must be an absolute
+    shared-storage path, contain no ``..``, and be neither the storage root nor a protected
+    top-level directory. This is a first-line syntactic guard; the client re-validates
+    against the real canonical filesystem before applying.
+    """
+    if not isinstance(dest, str) or not dest.strip():
+        return "Destination path is required"
+    text = dest.strip()
+    if "\x00" in text:
+        return "Destination path contains an invalid character"
+    if not text.startswith("/"):
+        return "Destination must be an absolute path"
+    # Reject on the raw path (matching the client) so a '..' that would normalize away here
+    # can't be accepted by the server yet rejected by the client's stricter raw check.
+    if ".." in text.split("/"):
+        return "Destination path must not contain '..'"
+    with_slash = os.path.normpath(text).rstrip("/") + "/"
+    prefix = next((p for p in SHARED_STORAGE_PREFIXES if with_slash.startswith(p)), None)
+    if prefix is None:
+        return "Destination must be under shared storage (/sdcard or /storage/emulated/0)"
+    remainder = with_slash[len(prefix):].strip("/")
+    if not remainder:
+        return "Destination must be a subdirectory, not the shared-storage root"
+    first_segment = remainder.split("/")[0]
+    if first_segment.lower() in PROTECTED_TOPLEVEL_DIRS:
+        return f"Destination must not be inside the protected '{first_segment}' directory"
+    return None
+
+
+def unique_bundle_path(filename: str) -> Path:
+    """Build a unique destination path in BUNDLE_DIR for a generated bundle zip."""
+    destination = BUNDLE_DIR / filename
+    if not destination.exists():
+        return destination
+
+    stem = destination.stem
+    suffix = destination.suffix
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    candidate = BUNDLE_DIR / f"{stem}-{timestamp}{suffix}"
+    counter = 2
+    while candidate.exists():
+        candidate = BUNDLE_DIR / f"{stem}-{timestamp}-{counter}{suffix}"
+        counter += 1
+    return candidate
+
+
+def bundle_basename(relpaths: list[str]) -> str:
+    """Derive a safe base name (no extension) for the bundle zip from its entries.
+
+    A single file → its stem; a folder tree sharing one top-level directory → that directory
+    name; otherwise → ``bundle``.
+    """
+    if not relpaths:
+        return "bundle"
+    if len(relpaths) == 1 and "/" not in relpaths[0]:
+        raw = Path(relpaths[0]).stem or "bundle"
+    else:
+        first_segments = {p.split("/")[0] for p in relpaths}
+        raw = next(iter(first_segments)) if len(first_segments) == 1 else "bundle"
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", raw).strip("._-")
+    return safe or "bundle"
+
+
+def strip_common_root(relpaths: list[str]) -> tuple[str | None, list[str]]:
+    """If every entry is nested under one shared top-level directory, return
+    ``(root_name, paths_without_root)``; otherwise ``(None, relpaths)``.
+
+    A folder pick (``webkitdirectory``) yields paths all prefixed with the picked
+    folder's name (``myfolder/a.txt``, ``myfolder/sub/b.txt``). The destination should
+    mirror that folder's *contents* (``a.txt``, ``sub/b.txt``) — "identical to the pushed
+    folder" — so the shared root is stripped from the archived paths and reused as the
+    bundle name. Single-file or multi-file picks (a bare filename among the entries) have
+    no shared directory root and are returned unchanged.
+    """
+    if not relpaths or any("/" not in p for p in relpaths):
+        return None, relpaths
+    roots = {p.split("/", 1)[0] for p in relpaths}
+    if len(roots) != 1:
+        return None, relpaths
+    root = next(iter(roots))
+    return root, [p.split("/", 1)[1] for p in relpaths]
+
+
+def zip_tree(root: Path, dest_zip: Path) -> None:
+    """Zip every file under ``root`` into ``dest_zip`` using forward-slash relative names."""
+    with zipfile.ZipFile(dest_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(root.rglob("*")):
+            if path.is_file():
+                zf.write(path, path.relative_to(root).as_posix())
+
+
+# ---------------------------------------------------------------------------
 # Device WebSocket handler  (/ws/device)
 # ---------------------------------------------------------------------------
 
@@ -516,7 +667,7 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     else:
                         log.warning("DOWNLOAD_COMPLETE before REGISTER")
 
-                elif msg_type in {"LAUNCH_RESULT", "INSTALL_RESULT"}:
+                elif msg_type in {"LAUNCH_RESULT", "INSTALL_RESULT", "PUSH_FILES_RESULT"}:
                     if device_id:
                         data.setdefault("device_id", device_id)
                     # Fallback transfer-slot release: an older client that never
@@ -590,6 +741,9 @@ async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
 
                 elif msg_type == "INSTALL_APK":
                     await handle_install_apk(ws, data)
+
+                elif msg_type == "PUSH_FILES":
+                    await handle_push_files(ws, data)
 
                 elif msg_type == "SET_STARTUP_APP":
                     await handle_set_startup_app(ws, data)
@@ -1137,6 +1291,71 @@ async def _run_install_job(apk_url: str, apk_filename: str, target_ids: list[str
     )
 
 
+async def handle_push_files(admin_ws: web.WebSocketResponse, data: dict):
+    """Process a PUSH_FILES command: validate then fan out EXECUTE_PUSH_FILES to target HMDs.
+
+    The destination is validated here as a first-line guard (full-mirror sync deletes extras,
+    so a bad path is destructive); the client re-validates against its real filesystem before
+    applying.
+    """
+    target_devices: list[str] = data.get("target_devices", [])
+    bundle_url: str = data.get("bundle_url", "")
+    bundle_filename: str = data.get("bundle_filename", "")
+    dest_path: str = (data.get("dest_path") or "").strip()
+
+    if not bundle_url:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "bundle_url is required",
+        }))
+        return
+
+    dest_error = validate_dest_path(dest_path)
+    if dest_error is not None:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": dest_error,
+        }))
+        return
+
+    target_ids = resolve_target_ids(target_devices)
+
+    if not target_ids:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "No matching online devices found",
+        }))
+        return
+
+    execute_msg = json.dumps({
+        "type": "EXECUTE_PUSH_FILES",
+        "bundle_url": bundle_url,
+        "bundle_filename": bundle_filename,
+        "dest_path": dest_path,
+    })
+
+    sent_count = 0
+    for did in target_ids:
+        entry = devices.get(did)
+        if entry:
+            try:
+                await entry["ws"].send_str(execute_msg)
+                sent_count += 1
+            except ConnectionResetError:
+                log.warning("Failed to send EXECUTE_PUSH_FILES to %s (disconnected)", did)
+
+    log.info("PUSH_FILES: sent %s -> %s to %d/%d devices",
+             bundle_filename or bundle_url, dest_path, sent_count, len(target_ids))
+
+    await admin_ws.send_str(json.dumps({
+        "type": "PUSH_FILES_SENT",
+        "bundle_filename": bundle_filename,
+        "dest_path": dest_path,
+        "sent_count": sent_count,
+        "target_count": len(target_ids),
+    }))
+
+
 # ---------------------------------------------------------------------------
 # APK upload handler
 # ---------------------------------------------------------------------------
@@ -1188,6 +1407,106 @@ async def upload_apk_handler(request: web.Request) -> web.Response:
         "apk_url": apk_url,
         "size": size,
     })
+
+
+# ---------------------------------------------------------------------------
+# File/folder bundle upload handler
+# ---------------------------------------------------------------------------
+
+async def upload_bundle_handler(request: web.Request) -> web.Response:
+    """Accept a file/folder upload, zip it into a bundle, and return its download URL.
+
+    Each multipart part is one file whose *filename* carries its (possibly nested) relative
+    path, so a whole folder tree can be uploaded with its structure preserved (the console
+    sends ``file.webkitRelativePath``). Parts are reconstructed under a temp directory with
+    per-path sanitization, then zipped; the temp tree is discarded and only the zip is kept.
+    """
+    try:
+        reader = await request.multipart()
+    except Exception as e:
+        return web.json_response({"error": f"Invalid multipart request: {e}"}, status=400)
+
+    BUNDLE_DIR.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix="upload-", dir=BUNDLE_DIR))
+    total_size = 0
+    relpaths: list[str] = []
+
+    try:
+        while True:
+            field = await reader.next()
+            if field is None:
+                break
+            if field.name != "files":
+                continue
+
+            # Browsers send the folder-relative path as the multipart filename; some
+            # multipart encoders percent-encode the path separators, so decode before
+            # sanitizing (sanitize_relpath still rejects any traversal after decoding).
+            raw_name = field.filename
+            relpath = sanitize_relpath(unquote(raw_name) if raw_name else None)
+            if relpath is None:
+                return web.json_response(
+                    {"error": f"Invalid file path in upload: {field.filename!r}"}, status=400)
+
+            if len(relpaths) >= MAX_BUNDLE_ENTRIES:
+                return web.json_response(
+                    {"error": f"Bundle exceeds the {MAX_BUNDLE_ENTRIES}-file limit"}, status=413)
+
+            target = staging / relpath
+            # Defense in depth: a sanitized relpath cannot escape, but confirm the join stays
+            # under the staging root before writing.
+            if not _is_within(staging, target):
+                return web.json_response({"error": "Invalid file path in upload"}, status=400)
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("wb") as f:
+                while True:
+                    chunk = await field.read_chunk(size=1024 * 1024)
+                    if not chunk:
+                        break
+                    total_size += len(chunk)
+                    if total_size > MAX_BUNDLE_SIZE:
+                        return web.json_response({"error": "Bundle exceeds 2 GiB limit"}, status=413)
+                    f.write(chunk)
+            relpaths.append(relpath)
+
+        if not relpaths:
+            return web.json_response({"error": "multipart field 'files' is required"}, status=400)
+
+        # A folder pick nests every file under the picked folder; mirror that folder's
+        # *contents* into the destination, so zip from the shared root (and name the
+        # bundle after it) rather than wrapping the destination in an extra directory.
+        root, _stripped = strip_common_root(relpaths)
+        content_root = staging / root if root is not None else staging
+        base = bundle_basename([root]) if root is not None else bundle_basename(relpaths)
+        bundle_path = unique_bundle_path(f"{base}.zip")
+        zip_tree(content_root, bundle_path)
+    except Exception as e:
+        log.exception("Failed to build uploaded bundle")
+        return web.json_response({"error": f"Failed to build bundle: {e}"}, status=500)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    size = bundle_path.stat().st_size
+    bundle_url = f"{request.scheme}://{request.host}/bundles/{bundle_path.name}"
+    log.info("Built bundle: %s (%d entries, %d bytes zipped)",
+             bundle_path.name, len(relpaths), size)
+
+    return web.json_response({
+        "bundle_filename": bundle_path.name,
+        "bundle_url": bundle_url,
+        "size": size,
+        "entry_count": len(relpaths),
+    })
+
+
+def _is_within(root: Path, target: Path) -> bool:
+    """Return True if ``target`` resolves to a path inside ``root``."""
+    try:
+        target.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
 
 
 async def handle_set_startup_app(admin_ws: web.WebSocketResponse, data: dict):
@@ -1395,12 +1714,14 @@ def create_app() -> web.Application:
     # Ensure the writable data directory exists before loading/saving the registry.
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     load_registry()
-    app = web.Application(client_max_size=MAX_APK_SIZE + 10 * 1024 * 1024)
+    app = web.Application(
+        client_max_size=max(MAX_APK_SIZE, MAX_BUNDLE_SIZE) + 10 * 1024 * 1024)
 
     # WebSocket endpoints
     app.router.add_get("/ws/device", device_ws_handler)
     app.router.add_get("/ws/admin", admin_ws_handler)
     app.router.add_post("/api/apks", upload_apk_handler)
+    app.router.add_post("/api/bundles", upload_bundle_handler)
 
     # Static files are shipped inside the package (styly_mdm/static/), so this
     # resolves both from source and when installed. It is read-only package data
@@ -1416,6 +1737,9 @@ def create_app() -> web.Application:
 
     APK_DIR.mkdir(parents=True, exist_ok=True)
     app.router.add_static("/apks", APK_DIR)
+
+    BUNDLE_DIR.mkdir(parents=True, exist_ok=True)
+    app.router.add_static("/bundles", BUNDLE_DIR)
 
     return app
 
@@ -1440,9 +1764,10 @@ def _apply_data_dir(path: str) -> None:
     Called from main() when --data-dir is passed. Reassigns the module globals so
     create_app() and the upload/registry handlers pick up the new location.
     """
-    global DATA_DIR, APK_DIR, REGISTRY_PATH
+    global DATA_DIR, APK_DIR, BUNDLE_DIR, REGISTRY_PATH
     DATA_DIR = Path(path).resolve()
     APK_DIR = DATA_DIR / "apks"
+    BUNDLE_DIR = DATA_DIR / "bundles"
     REGISTRY_PATH = DATA_DIR / "device_registry.json"
 
 

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -469,8 +469,9 @@ def sanitize_relpath(raw: str | None) -> str | None:
 def validate_dest_path(dest: str | None) -> str | None:
     """Return an error message if a device destination path is unsafe, else None.
 
-    Full-mirror sync deletes anything at the destination not in the bundle, so a wrong path
-    would wipe unrelated data on every selected device. The path must be an absolute
+    A full-mirror sync deletes anything at the destination not in the bundle, so a wrong path
+    would wipe unrelated data on every selected device. Pushes are held to the same rule, so a
+    copy cannot quietly reach somewhere a sync may not. The path must be an absolute
     shared-storage path, contain no ``..``, and be neither the storage root nor a protected
     top-level directory. This is a first-line syntactic guard; the client re-validates
     against the real canonical filesystem before applying.
@@ -1294,14 +1295,19 @@ async def _run_install_job(apk_url: str, apk_filename: str, target_ids: list[str
 async def handle_push_files(admin_ws: web.WebSocketResponse, data: dict):
     """Process a PUSH_FILES command: validate then fan out EXECUTE_PUSH_FILES to target HMDs.
 
-    The destination is validated here as a first-line guard (full-mirror sync deletes extras,
-    so a bad path is destructive); the client re-validates against its real filesystem before
-    applying.
+    ``delete_extras`` selects the semantics the client applies: false (the default) copies and
+    overwrites without deleting anything; true full-mirrors, pruning whatever at the destination
+    is not in the bundle. The server only passes the flag through — the delete itself lives in
+    the client — but it coerces the value here so a malformed field cannot decode to true.
+
+    The destination is validated here as a first-line guard (a mirror deletes extras, so a bad
+    path is destructive); the client re-validates against its real filesystem before applying.
     """
     target_devices: list[str] = data.get("target_devices", [])
     bundle_url: str = data.get("bundle_url", "")
     bundle_filename: str = data.get("bundle_filename", "")
     dest_path: str = (data.get("dest_path") or "").strip()
+    delete_extras: bool = data.get("delete_extras") is True
 
     if not bundle_url:
         await admin_ws.send_str(json.dumps({
@@ -1332,6 +1338,7 @@ async def handle_push_files(admin_ws: web.WebSocketResponse, data: dict):
         "bundle_url": bundle_url,
         "bundle_filename": bundle_filename,
         "dest_path": dest_path,
+        "delete_extras": delete_extras,
     })
 
     sent_count = 0
@@ -1344,13 +1351,15 @@ async def handle_push_files(admin_ws: web.WebSocketResponse, data: dict):
             except ConnectionResetError:
                 log.warning("Failed to send EXECUTE_PUSH_FILES to %s (disconnected)", did)
 
-    log.info("PUSH_FILES: sent %s -> %s to %d/%d devices",
+    log.info("PUSH_FILES (%s): sent %s -> %s to %d/%d devices",
+             "sync" if delete_extras else "copy",
              bundle_filename or bundle_url, dest_path, sent_count, len(target_ids))
 
     await admin_ws.send_str(json.dumps({
         "type": "PUSH_FILES_SENT",
         "bundle_filename": bundle_filename,
         "dest_path": dest_path,
+        "delete_extras": delete_extras,
         "sent_count": sent_count,
         "target_count": len(target_ids),
     }))

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1439,6 +1439,7 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
     staging = Path(tempfile.mkdtemp(prefix="upload-", dir=BUNDLE_DIR))
     total_size = 0
     relpaths: list[str] = []
+    skipped: list[str] = []
 
     try:
         while True:
@@ -1456,6 +1457,12 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
             if relpath is None:
                 return web.json_response(
                     {"error": f"Invalid file path in upload: {field.filename!r}"}, status=400)
+
+            # Drop OS metadata before it is written to staging, so it never reaches the zip
+            # and never counts against the entry limit. reader.next() drains the skipped part.
+            if is_excluded_bundle_entry(relpath):
+                skipped.append(relpath)
+                continue
 
             if len(relpaths) >= MAX_BUNDLE_ENTRIES:
                 return web.json_response(
@@ -1480,6 +1487,10 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
             relpaths.append(relpath)
 
         if not relpaths:
+            if skipped:
+                return web.json_response(
+                    {"error": "Upload contained only OS metadata files; nothing to send"},
+                    status=400)
             return web.json_response({"error": "multipart field 'files' is required"}, status=400)
 
         # A folder pick nests every file under the picked folder; mirror that folder's
@@ -1500,13 +1511,68 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
     bundle_url = f"{request.scheme}://{request.host}/bundles/{bundle_path.name}"
     log.info("Built bundle: %s (%d entries, %d bytes zipped)",
              bundle_path.name, len(relpaths), size)
+    if skipped:
+        log.info("Excluded %d OS metadata file(s) from %s: %s",
+                 len(skipped), bundle_path.name, ", ".join(skipped[:10]))
 
     return web.json_response({
         "bundle_filename": bundle_path.name,
         "bundle_url": bundle_url,
         "size": size,
         "entry_count": len(relpaths),
+        "skipped_count": len(skipped),
     })
+
+
+# OS-generated metadata that rides along with a folder pick. None of it is content the user
+# meant to upload, and a folder copied via USB can carry one `._*` sidecar per file, so these
+# are dropped when the bundle is built rather than shipped to every device.
+#
+# Deliberately limited to files the OS creates on its own. Anything a user could plausibly
+# have authored — `.git/`, Unity `.meta`, dotfiles at large — is uploaded as-is: a silent drop
+# of real content would be far worse than an unwanted `.DS_Store`.
+_EXCLUDED_NAMES = frozenset({
+    ".ds_store",              # macOS Finder, one per directory
+    "thumbs.db",              # Windows Explorer thumbnail cache
+    "ehthumbs.db",
+    "desktop.ini",            # Windows folder settings
+    ".directory",             # KDE folder settings
+    ".apdisk",                # macOS
+    ".volumeicon.icns",       # macOS
+})
+
+# Directories the OS owns end-to-end; excluding the directory excludes everything under it.
+_EXCLUDED_DIRS = frozenset({
+    ".spotlight-v100",
+    ".trashes",
+    ".fseventsd",
+    ".temporaryitems",
+    ".documentrevisions-v100",
+    "__macosx",               # created when a macOS-made zip is expanded
+    "$recycle.bin",
+})
+
+
+def is_excluded_bundle_entry(relpath: str) -> bool:
+    """Return True if any path segment of ``relpath`` is OS-generated metadata.
+
+    Matching is case-insensitive: the same file is ``Thumbs.db`` on one machine and
+    ``thumbs.db`` on another, and macOS/Windows filesystems do not distinguish them.
+    Matching on *any* segment means a file nested under an excluded directory is dropped
+    along with it.
+    """
+    for seg in relpath.split("/"):
+        low = seg.lower()
+        if low in _EXCLUDED_NAMES or low in _EXCLUDED_DIRS:
+            return True
+        # AppleDouble resource forks: one `._name` sidecar per file, created whenever a
+        # macOS folder is copied onto a non-HFS filesystem such as a USB stick.
+        if low.startswith("._"):
+            return True
+        # Per-user trash directories on Linux removable media (`.Trash-1000`).
+        if low.startswith(".trash-"):
+            return True
+    return False
 
 
 def _is_within(root: Path, target: Path) -> bool:

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -223,6 +223,8 @@
     .file-name strong { color: var(--text-primary); font-weight: 600; }
     .push-warn { font-size: 11.5px; line-height: 1.5; color: var(--warning); background: var(--bg-card); border: 1px solid #5a4a1c; border-radius: 6px; padding: 8px 10px; margin-top: 7px; }
     .push-warn code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+    .push-note { font-size: 11.5px; line-height: 1.5; color: var(--text-secondary); background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: 6px; padding: 8px 10px; margin-top: 7px; }
+    .push-note code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
     .push-confirm { display: flex; align-items: flex-start; gap: 7px; font-size: 12px; color: var(--text-secondary); margin-top: 7px; cursor: pointer; }
     .push-confirm input { margin-top: 1px; flex-shrink: 0; }
 
@@ -362,9 +364,23 @@
                   <span class="file-name" id="pushName">No file or folder selected</span>
                 </div>
                 <input type="text" class="field" id="pushDest" placeholder="/sdcard/STYLY/content">
-                <div class="push-warn">⚠ Full-mirror sync into the destination directory. A picked folder's <em>contents</em> are mirrored into it (e.g. folder <code>content</code> → files land directly in the destination). Files already under the destination that are <strong>not</strong> in this upload will be <strong>deleted</strong> on every selected device. Destinations must be under shared storage (e.g. <code>/sdcard/…</code>) — app-private folders are not reachable.</div>
-                <label class="push-confirm"><input type="checkbox" id="pushConfirm"> I understand extras at the destination will be deleted</label>
+                <div class="push-note">Copies into the destination directory, overwriting files of the same name. Nothing already at the destination is deleted. A picked folder's <em>contents</em> land directly in the destination. Destinations must be under shared storage (e.g. <code>/sdcard/…</code>) — app-private folders are not reachable.</div>
                 <button class="btn btn-success" id="btnPush" disabled>Push to Selected</button>
+              </div>
+            </div>
+            <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="sync">
+              <div class="cmd-head" data-act="toggleCmd"><span>Sync Folder</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <div class="file-row">
+                  <label class="file-pick" for="syncFolder">Choose Folder</label>
+                  <input type="file" id="syncFolder" webkitdirectory hidden>
+                  <span class="file-name" id="syncName">No folder selected</span>
+                </div>
+                <input type="text" class="field" id="syncDest" placeholder="/sdcard/STYLY/content">
+                <div class="push-warn">⚠ Full-mirror sync into the destination directory. The picked folder's <em>contents</em> are mirrored into it (e.g. folder <code>content</code> → files land directly in the destination). Files already under the destination that are <strong>not</strong> in this upload will be <strong>deleted</strong> on every selected device. Destinations must be under shared storage (e.g. <code>/sdcard/…</code>) — app-private folders are not reachable.</div>
+                <label class="push-confirm"><input type="checkbox" id="syncConfirm"> I understand extras at the destination will be deleted</label>
+                <button class="btn btn-success" id="btnSync" disabled>Sync to Selected</button>
               </div>
             </div>
             <div class="cmd-divider"></div>
@@ -431,12 +447,10 @@
       let userPickedTab = false;       // true once the user clicks a sub-tab (stops auto-default)
       let expandedGroups = new Set();  // group names expanded to show per-device status
       let view = 'console';            // 'console' | 'manage'
-      let installState = {};           // id -> { status, filename, detail }
+      let installState = {};           // id -> { task, status, filename, detail, note, verb }
       let editingLabelId = null;
       let uploadedApk = null;
       let uploadInProgress = false;
-      let uploadedBundle = null;
-      let bundleUploadInProgress = false;
       let reconnectTimer = null;
       const RECONNECT_DELAY = 3000;
       const LOW_BATTERY_THRESHOLD = 20;
@@ -462,12 +476,6 @@
       const apkFile = document.getElementById('apkFile');
       const apkName = document.getElementById('apkName');
       const btnInstall = document.getElementById('btnInstall');
-      const pushFile = document.getElementById('pushFile');
-      const pushFolder = document.getElementById('pushFolder');
-      const pushName = document.getElementById('pushName');
-      const pushDest = document.getElementById('pushDest');
-      const pushConfirm = document.getElementById('pushConfirm');
-      const btnPush = document.getElementById('btnPush');
       const launchPkg = document.getElementById('launchPkg');
       const launchExtra = document.getElementById('launchExtra');
       const btnLaunch = document.getElementById('btnLaunch');
@@ -578,19 +586,22 @@
             addLog('[' + (msg.status === 'success' ? 'OK' : 'FAIL') + '] install ' + (msg.apk_filename || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), st);
             break;
           }
-          case 'PUSH_FILES_SENT': addLog('Push command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s) → ' + (msg.dest_path || '-'), 'info'); break;
+          case 'PUSH_FILES_SENT': addLog((msg.delete_extras ? 'Sync' : 'Push') + ' command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s) → ' + (msg.dest_path || '-'), 'info'); break;
           case 'PUSH_FILES_RESULT': {
             const st = msg.status === 'success' ? 'success' : 'fail';
             const summary = '+' + (msg.added || 0) + ' ~' + (msg.updated || 0) + ' -' + (msg.deleted || 0);
             const detail = msg.error || msg.message || '';
+            const prev = msg.device_id ? installState[msg.device_id] : null;
+            const verb = (prev && prev.task === 'push' && prev.verb) || 'Push';
             if (msg.device_id) {
-              installState[msg.device_id] = { task: 'push', status: st, filename: msg.dest_path || '', note: st === 'success' ? summary : '', detail: detail };
+              installState[msg.device_id] = { task: 'push', status: st, verb: verb, filename: msg.dest_path || '', note: st === 'success' ? summary : '', detail: detail };
               updateInstallCell(msg.device_id);
             }
+            const what = verb.toLowerCase();
             if (st === 'success') {
-              addLog('[OK] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + ' (' + summary + ')', 'success');
+              addLog('[OK] ' + what + ' to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + ' (' + summary + ')', 'success');
             } else {
-              addLog('[FAIL] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), 'fail');
+              addLog('[FAIL] ' + what + ' to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), 'fail');
             }
             break;
           }
@@ -762,8 +773,12 @@
         const st = installState[id];
         if (!st) return '<span class="ins-none">—</span>';
         if (st.task === 'push') {
-          if (st.status === 'pushing') return '<span class="ins-installing"><span class="spinner">⟳</span> Pushing…</span>';
-          if (st.status === 'success') return '<span class="ins-success">✓ pushed</span>' + (st.note ? ' <span class="ins-none">' + esc(st.note) + '</span>' : '');
+          // `verb` is set when the console dispatches, and carried onto the result so a synced
+          // device does not report itself as "pushed". PUSH_FILES_RESULT does not name the
+          // mode, so a page reloaded mid-job falls back to the neutral "Push".
+          const verb = st.verb || 'Push';
+          if (st.status === 'pushing') return '<span class="ins-installing"><span class="spinner">⟳</span> ' + esc(verb) + 'ing…</span>';
+          if (st.status === 'success') return '<span class="ins-success">✓ ' + esc(verb.toLowerCase()) + 'ed</span>' + (st.note ? ' <span class="ins-none">' + esc(st.note) + '</span>' : '');
           return '<span class="ins-fail" title="' + esc(st.detail || '') + '">✗ failed</span>' + (st.detail ? ' <span class="ins-none">' + esc(st.detail) + '</span>' : '');
         }
         if (st.status === 'queued') return '<span class="ins-queued">◦ Waiting…</span>';
@@ -800,7 +815,6 @@
         updateButtons();
       }
 
-      function hasPushSelection() { return pushFile.files.length > 0 || pushFolder.files.length > 0; }
 
       function updateButtons() {
         const has = selectedIds.size > 0;
@@ -808,7 +822,8 @@
         btnLaunch.disabled = launchPkg.value.trim() === '' || !has;
         btnStartupSet.disabled = startupPkg.value.trim() === '' || !has;
         btnStartupClear.disabled = !has;
-        btnPush.disabled = bundleUploadInProgress || !hasPushSelection() || pushDest.value.trim() === '' || !pushConfirm.checked || !has;
+        pushPanel.refreshButton(has);
+        syncPanel.refreshButton(has);
       }
 
       // ---------------- Selection actions ----------------
@@ -891,50 +906,121 @@
         }).catch(function (err) { apkName.textContent = 'Upload failed'; addLog('APK install failed: ' + err.message, 'fail'); });
       }
 
-      function pushSelectionFiles() {
-        // Either a set of individual files (pushFile) or a folder tree (pushFolder).
-        return pushFolder.files.length > 0 ? Array.from(pushFolder.files) : Array.from(pushFile.files);
+      // Push and Sync are the same transport (upload a bundle, fan out PUSH_FILES) over two
+      // very different destination semantics, so they are two panels sharing one factory
+      // rather than one panel with a delete toggle: the destructive one has to be chosen by
+      // name. `deleteExtras` rides the wire; the delete itself happens on the device.
+      //
+      // Push takes files or a folder and only ever copies/overwrites. Sync takes a folder and
+      // full-mirrors, so it alone carries the warning and the confirmation checkbox.
+      function createPushPanel(cfg) {
+        const fileInput = cfg.fileId ? document.getElementById(cfg.fileId) : null;
+        const folderInput = document.getElementById(cfg.folderId);
+        const nameEl = document.getElementById(cfg.nameId);
+        const destEl = document.getElementById(cfg.destId);
+        const confirmEl = cfg.confirmId ? document.getElementById(cfg.confirmId) : null;
+        const btn = document.getElementById(cfg.btnId);
+        let uploaded = null;
+        let uploading = false;
+
+        function selectionFiles() {
+          if (folderInput.files.length) return Array.from(folderInput.files);
+          return fileInput ? Array.from(fileInput.files) : [];
+        }
+
+        function describeSelection() {
+          const folder = Array.from(folderInput.files);
+          if (folder.length) {
+            const top = (folder[0].webkitRelativePath || '').split('/')[0] || 'folder';
+            const bytes = folder.reduce(function (sum, f) { return sum + f.size; }, 0);
+            return 'Selected folder: ' + top + ' (' + folder.length + ' files, ' + formatBytes(bytes) + ')';
+          }
+          const files = fileInput ? Array.from(fileInput.files) : [];
+          if (!files.length) return cfg.emptyLabel;
+          if (files.length === 1) return 'Selected: ' + files[0].name + ' (' + formatBytes(files[0].size) + ')';
+          const bytes = files.reduce(function (sum, f) { return sum + f.size; }, 0);
+          return 'Selected ' + files.length + ' files (' + formatBytes(bytes) + ')';
+        }
+
+        function reset() {
+          if (fileInput) fileInput.value = '';
+          folderInput.value = '';
+          uploaded = null;
+          if (confirmEl) confirmEl.checked = false;
+          nameEl.textContent = cfg.emptyLabel;
+          updateButtons();
+        }
+
+        function ensureUploaded() {
+          if (uploaded) return Promise.resolve(uploaded);
+          const files = selectionFiles();
+          if (!files.length) return Promise.reject(new Error(cfg.emptyLabel));
+          const fd = new FormData();
+          // Send each file's relative path as its multipart filename so the server can rebuild
+          // the folder tree; webkitRelativePath is set for folder picks, empty for single files.
+          files.forEach(function (f) { fd.append('files', f, f.webkitRelativePath || f.name); });
+          uploading = true; nameEl.textContent = 'Uploading ' + files.length + ' file(s)...'; updateButtons();
+          return fetch('/api/bundles', { method: 'POST', body: fd })
+            .then(function (r) { return r.json().catch(function () { return {}; }).then(function (p) { if (!r.ok) throw new Error(p.error || r.statusText); return p; }); })
+            .then(function (p) { uploaded = p; nameEl.innerHTML = 'Uploaded: <strong>' + esc(p.bundle_filename) + '</strong> (' + p.entry_count + ' file(s), ' + formatBytes(p.size) + ')'; addLog('Uploaded bundle: ' + p.bundle_filename + ' (' + p.entry_count + ' file(s))', 'success'); return p; })
+            .finally(function () { uploading = false; updateButtons(); });
+        }
+
+        function send() {
+          if (uploading) return;
+          const dest = destEl.value.trim();
+          if (!dest) { addLog('Enter a destination path to ' + cfg.verb.toLowerCase() + ' files', 'warn'); return; }
+          if (confirmEl && !confirmEl.checked) { addLog('Confirm the delete warning before syncing', 'warn'); return; }
+          const online = onlineTargets(Array.from(selectedIds));
+          if (!online.length) { addLog('No online devices selected to ' + cfg.verb.toLowerCase() + ' files', 'warn'); return; }
+          ensureUploaded().then(function (bundle) {
+            const msg = {
+              type: 'PUSH_FILES', target_devices: online, bundle_url: bundle.bundle_url,
+              bundle_filename: bundle.bundle_filename, dest_path: dest, delete_extras: cfg.deleteExtras,
+            };
+            if (!wsSend(msg, cfg.verb.toLowerCase() + ' files')) return;
+            // Optimistic first paint: the fan-out is not throttled, so every online target
+            // really is working from here until its PUSH_FILES_RESULT arrives, or DEVICE_LIST
+            // drops it as offline.
+            online.forEach(function (id) { installState[id] = { task: 'push', status: 'pushing', verb: cfg.verb, filename: dest, note: '', detail: '' }; updateInstallCell(id); });
+            addLog(cfg.verb + 'ing ' + bundle.bundle_filename + ' → ' + dest + ' on ' + online.length + ' device(s)', 'info');
+            // Force a fresh pick next time (LAN/non-secure context cannot detect a local change).
+            reset();
+          }).catch(function (err) { nameEl.textContent = 'Upload failed'; addLog(cfg.verb + ' files failed: ' + err.message, 'fail'); });
+        }
+
+        function hasSelection() { return selectionFiles().length > 0; }
+
+        function refreshButton(anySelected) {
+          btn.disabled = uploading || !hasSelection() || destEl.value.trim() === '' ||
+            (confirmEl ? !confirmEl.checked : false) || !anySelected;
+        }
+
+        function onPick(input, other) {
+          input.addEventListener('change', function () {
+            if (input.files.length && other) other.value = '';
+            uploaded = null; nameEl.textContent = describeSelection(); updateButtons();
+          });
+        }
+        if (fileInput) onPick(fileInput, folderInput);
+        onPick(folderInput, fileInput);
+        destEl.addEventListener('input', updateButtons);
+        if (confirmEl) confirmEl.addEventListener('change', updateButtons);
+        btn.addEventListener('click', send);
+
+        return { refreshButton: refreshButton };
       }
 
-      function resetPushSelection() {
-        pushFile.value = ''; pushFolder.value = ''; uploadedBundle = null;
-        pushConfirm.checked = false; pushName.textContent = 'No file or folder selected';
-        updateButtons();
-      }
-
-      function ensureBundleUploaded() {
-        if (uploadedBundle) return Promise.resolve(uploadedBundle);
-        const files = pushSelectionFiles();
-        if (!files.length) return Promise.reject(new Error('No file or folder selected'));
-        const fd = new FormData();
-        // Send each file's relative path as its multipart filename so the server can rebuild
-        // the folder tree; webkitRelativePath is set for folder picks, empty for single files.
-        files.forEach(function (f) { fd.append('files', f, f.webkitRelativePath || f.name); });
-        bundleUploadInProgress = true; pushName.textContent = 'Uploading ' + files.length + ' file(s)...'; updateButtons();
-        return fetch('/api/bundles', { method: 'POST', body: fd })
-          .then(function (r) { return r.json().catch(function () { return {}; }).then(function (p) { if (!r.ok) throw new Error(p.error || r.statusText); return p; }); })
-          .then(function (p) { uploadedBundle = p; pushName.innerHTML = 'Uploaded: <strong>' + esc(p.bundle_filename) + '</strong> (' + p.entry_count + ' file(s), ' + formatBytes(p.size) + ')'; addLog('Uploaded bundle: ' + p.bundle_filename + ' (' + p.entry_count + ' file(s))', 'success'); return p; })
-          .finally(function () { bundleUploadInProgress = false; updateButtons(); });
-      }
-
-      function sendPush() {
-        if (bundleUploadInProgress) return;
-        const dest = pushDest.value.trim();
-        if (!dest) { addLog('Enter a destination path to push files', 'warn'); return; }
-        if (!pushConfirm.checked) { addLog('Confirm the delete warning before pushing', 'warn'); return; }
-        const online = onlineTargets(Array.from(selectedIds));
-        if (!online.length) { addLog('No online devices selected to push files', 'warn'); return; }
-        ensureBundleUploaded().then(function (bundle) {
-          if (!wsSend({ type: 'PUSH_FILES', target_devices: online, bundle_url: bundle.bundle_url, bundle_filename: bundle.bundle_filename, dest_path: dest }, 'push files')) return;
-          // Optimistic first paint: a push is dispatched to every online target at once
-          // (no throttle), so each one really is pushing from here until its
-          // PUSH_FILES_RESULT arrives, or DEVICE_LIST drops it as offline.
-          online.forEach(function (id) { installState[id] = { task: 'push', status: 'pushing', filename: dest, note: '', detail: '' }; updateInstallCell(id); });
-          addLog('Pushing ' + bundle.bundle_filename + ' → ' + dest + ' on ' + online.length + ' device(s)', 'info');
-          // Force a fresh pick next time (LAN/non-secure context cannot detect a local change).
-          resetPushSelection();
-        }).catch(function (err) { pushName.textContent = 'Upload failed'; addLog('Push files failed: ' + err.message, 'fail'); });
-      }
+      const pushPanel = createPushPanel({
+        fileId: 'pushFile', folderId: 'pushFolder', nameId: 'pushName', destId: 'pushDest',
+        btnId: 'btnPush', verb: 'Push', deleteExtras: false,
+        emptyLabel: 'No file or folder selected',
+      });
+      const syncPanel = createPushPanel({
+        folderId: 'syncFolder', nameId: 'syncName', destId: 'syncDest', confirmId: 'syncConfirm',
+        btnId: 'btnSync', verb: 'Sync', deleteExtras: true,
+        emptyLabel: 'No folder selected',
+      });
 
       function sendSetStartup() {
         const pkg = startupPkg.value.trim();
@@ -1168,30 +1254,6 @@
         apkName.textContent = f ? ('Selected: ' + f.name + ' (' + formatBytes(f.size) + ')') : 'No APK selected';
         updateButtons();
       });
-      function describePushSelection() {
-        const folder = Array.from(pushFolder.files);
-        if (folder.length) {
-          const top = (folder[0].webkitRelativePath || '').split('/')[0] || 'folder';
-          const bytes = folder.reduce(function (sum, f) { return sum + f.size; }, 0);
-          return 'Selected folder: ' + top + ' (' + folder.length + ' files, ' + formatBytes(bytes) + ')';
-        }
-        const files = Array.from(pushFile.files);
-        if (!files.length) return 'No file or folder selected';
-        if (files.length === 1) return 'Selected: ' + files[0].name + ' (' + formatBytes(files[0].size) + ')';
-        const bytes = files.reduce(function (sum, f) { return sum + f.size; }, 0);
-        return 'Selected ' + files.length + ' files (' + formatBytes(bytes) + ')';
-      }
-      pushFile.addEventListener('change', function () {
-        if (pushFile.files.length) pushFolder.value = '';
-        uploadedBundle = null; pushName.textContent = describePushSelection(); updateButtons();
-      });
-      pushFolder.addEventListener('change', function () {
-        if (pushFolder.files.length) pushFile.value = '';
-        uploadedBundle = null; pushName.textContent = describePushSelection(); updateButtons();
-      });
-      pushDest.addEventListener('input', updateButtons);
-      pushConfirm.addEventListener('change', updateButtons);
-      btnPush.addEventListener('click', sendPush);
       launchPkg.addEventListener('input', updateButtons);
       startupPkg.addEventListener('input', updateButtons);
       btnInstall.addEventListener('click', sendInstall);

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -221,6 +221,10 @@
     .file-pick { background: var(--bg-tertiary); border-radius: 5px; padding: 5px 11px; font-size: 12px; color: #cfd3e3; cursor: pointer; white-space: nowrap; }
     .file-name { font-size: 12px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .file-name strong { color: var(--text-primary); font-weight: 600; }
+    .push-warn { font-size: 11.5px; line-height: 1.5; color: var(--warning); background: var(--bg-card); border: 1px solid #5a4a1c; border-radius: 6px; padding: 8px 10px; margin-top: 7px; }
+    .push-warn code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+    .push-confirm { display: flex; align-items: flex-start; gap: 7px; font-size: 12px; color: var(--text-secondary); margin-top: 7px; cursor: pointer; }
+    .push-confirm input { margin-top: 1px; flex-shrink: 0; }
 
     .btn { padding: 10px; border: none; border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer; font-family: inherit; width: 100%; text-align: center; margin-top: 8px; transition: opacity .2s, background .2s; }
     .btn:disabled { opacity: .4; cursor: not-allowed; }
@@ -347,6 +351,23 @@
               </div>
             </div>
             <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="push">
+              <div class="cmd-head" data-act="toggleCmd"><span>Push Files</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <div class="file-row">
+                  <label class="file-pick" for="pushFile">Choose File</label>
+                  <input type="file" id="pushFile" multiple hidden>
+                  <label class="file-pick" for="pushFolder">Choose Folder</label>
+                  <input type="file" id="pushFolder" webkitdirectory hidden>
+                  <span class="file-name" id="pushName">No file or folder selected</span>
+                </div>
+                <input type="text" class="field" id="pushDest" placeholder="/sdcard/STYLY/content">
+                <div class="push-warn">⚠ Full-mirror sync into the destination directory. A picked folder's <em>contents</em> are mirrored into it (e.g. folder <code>content</code> → files land directly in the destination). Files already under the destination that are <strong>not</strong> in this upload will be <strong>deleted</strong> on every selected device. Destinations must be under shared storage (e.g. <code>/sdcard/…</code>) — app-private folders are not reachable.</div>
+                <label class="push-confirm"><input type="checkbox" id="pushConfirm"> I understand extras at the destination will be deleted</label>
+                <button class="btn btn-success" id="btnPush" disabled>Push to Selected</button>
+              </div>
+            </div>
+            <div class="cmd-divider"></div>
             <div class="cmd-section collapsed" data-cmd="launch">
               <div class="cmd-head" data-act="toggleCmd"><span>Launch Command</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
@@ -414,6 +435,8 @@
       let editingLabelId = null;
       let uploadedApk = null;
       let uploadInProgress = false;
+      let uploadedBundle = null;
+      let bundleUploadInProgress = false;
       let reconnectTimer = null;
       const RECONNECT_DELAY = 3000;
       const LOW_BATTERY_THRESHOLD = 20;
@@ -439,6 +462,12 @@
       const apkFile = document.getElementById('apkFile');
       const apkName = document.getElementById('apkName');
       const btnInstall = document.getElementById('btnInstall');
+      const pushFile = document.getElementById('pushFile');
+      const pushFolder = document.getElementById('pushFolder');
+      const pushName = document.getElementById('pushName');
+      const pushDest = document.getElementById('pushDest');
+      const pushConfirm = document.getElementById('pushConfirm');
+      const btnPush = document.getElementById('btnPush');
       const launchPkg = document.getElementById('launchPkg');
       const launchExtra = document.getElementById('launchExtra');
       const btnLaunch = document.getElementById('btnLaunch');
@@ -547,6 +576,18 @@
             const detail = msg.error || msg.message || '';
             if (msg.device_id) { installState[msg.device_id] = { status: st, filename: msg.apk_filename || '', detail: detail }; updateInstallCell(msg.device_id); }
             addLog('[' + (msg.status === 'success' ? 'OK' : 'FAIL') + '] install ' + (msg.apk_filename || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), st);
+            break;
+          }
+          case 'PUSH_FILES_SENT': addLog('Push command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s) → ' + (msg.dest_path || '-'), 'info'); break;
+          case 'PUSH_FILES_RESULT': {
+            const st = msg.status === 'success' ? 'success' : 'fail';
+            if (st === 'success') {
+              const summary = '+' + (msg.added || 0) + ' ~' + (msg.updated || 0) + ' -' + (msg.deleted || 0);
+              addLog('[OK] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + ' (' + summary + ')', 'success');
+            } else {
+              const detail = msg.error || msg.message || '';
+              addLog('[FAIL] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), 'fail');
+            }
             break;
           }
           case 'DEVICE_LABEL_SET': addLog('Label set: ' + (msg.device_id || '-') + ' -> ' + (msg.label || '(cleared)'), 'success'); break;
@@ -745,12 +786,15 @@
         updateButtons();
       }
 
+      function hasPushSelection() { return pushFile.files.length > 0 || pushFolder.files.length > 0; }
+
       function updateButtons() {
         const has = selectedIds.size > 0;
         btnInstall.disabled = uploadInProgress || apkFile.files.length === 0 || !has;
         btnLaunch.disabled = launchPkg.value.trim() === '' || !has;
         btnStartupSet.disabled = startupPkg.value.trim() === '' || !has;
         btnStartupClear.disabled = !has;
+        btnPush.disabled = bundleUploadInProgress || !hasPushSelection() || pushDest.value.trim() === '' || !pushConfirm.checked || !has;
       }
 
       // ---------------- Selection actions ----------------
@@ -831,6 +875,47 @@
           // Force a fresh pick next time (LAN/non-secure context cannot detect a local rebuild).
           apkFile.value = ''; uploadedApk = null; apkName.textContent = 'No APK selected'; updateButtons();
         }).catch(function (err) { apkName.textContent = 'Upload failed'; addLog('APK install failed: ' + err.message, 'fail'); });
+      }
+
+      function pushSelectionFiles() {
+        // Either a set of individual files (pushFile) or a folder tree (pushFolder).
+        return pushFolder.files.length > 0 ? Array.from(pushFolder.files) : Array.from(pushFile.files);
+      }
+
+      function resetPushSelection() {
+        pushFile.value = ''; pushFolder.value = ''; uploadedBundle = null;
+        pushConfirm.checked = false; pushName.textContent = 'No file or folder selected';
+        updateButtons();
+      }
+
+      function ensureBundleUploaded() {
+        if (uploadedBundle) return Promise.resolve(uploadedBundle);
+        const files = pushSelectionFiles();
+        if (!files.length) return Promise.reject(new Error('No file or folder selected'));
+        const fd = new FormData();
+        // Send each file's relative path as its multipart filename so the server can rebuild
+        // the folder tree; webkitRelativePath is set for folder picks, empty for single files.
+        files.forEach(function (f) { fd.append('files', f, f.webkitRelativePath || f.name); });
+        bundleUploadInProgress = true; pushName.textContent = 'Uploading ' + files.length + ' file(s)...'; updateButtons();
+        return fetch('/api/bundles', { method: 'POST', body: fd })
+          .then(function (r) { return r.json().catch(function () { return {}; }).then(function (p) { if (!r.ok) throw new Error(p.error || r.statusText); return p; }); })
+          .then(function (p) { uploadedBundle = p; pushName.innerHTML = 'Uploaded: <strong>' + esc(p.bundle_filename) + '</strong> (' + p.entry_count + ' file(s), ' + formatBytes(p.size) + ')'; addLog('Uploaded bundle: ' + p.bundle_filename + ' (' + p.entry_count + ' file(s))', 'success'); return p; })
+          .finally(function () { bundleUploadInProgress = false; updateButtons(); });
+      }
+
+      function sendPush() {
+        if (bundleUploadInProgress) return;
+        const dest = pushDest.value.trim();
+        if (!dest) { addLog('Enter a destination path to push files', 'warn'); return; }
+        if (!pushConfirm.checked) { addLog('Confirm the delete warning before pushing', 'warn'); return; }
+        const online = onlineTargets(Array.from(selectedIds));
+        if (!online.length) { addLog('No online devices selected to push files', 'warn'); return; }
+        ensureBundleUploaded().then(function (bundle) {
+          if (!wsSend({ type: 'PUSH_FILES', target_devices: online, bundle_url: bundle.bundle_url, bundle_filename: bundle.bundle_filename, dest_path: dest }, 'push files')) return;
+          addLog('Pushing ' + bundle.bundle_filename + ' → ' + dest + ' on ' + online.length + ' device(s)', 'info');
+          // Force a fresh pick next time (LAN/non-secure context cannot detect a local change).
+          resetPushSelection();
+        }).catch(function (err) { pushName.textContent = 'Upload failed'; addLog('Push files failed: ' + err.message, 'fail'); });
       }
 
       function sendSetStartup() {
@@ -1065,6 +1150,30 @@
         apkName.textContent = f ? ('Selected: ' + f.name + ' (' + formatBytes(f.size) + ')') : 'No APK selected';
         updateButtons();
       });
+      function describePushSelection() {
+        const folder = Array.from(pushFolder.files);
+        if (folder.length) {
+          const top = (folder[0].webkitRelativePath || '').split('/')[0] || 'folder';
+          const bytes = folder.reduce(function (sum, f) { return sum + f.size; }, 0);
+          return 'Selected folder: ' + top + ' (' + folder.length + ' files, ' + formatBytes(bytes) + ')';
+        }
+        const files = Array.from(pushFile.files);
+        if (!files.length) return 'No file or folder selected';
+        if (files.length === 1) return 'Selected: ' + files[0].name + ' (' + formatBytes(files[0].size) + ')';
+        const bytes = files.reduce(function (sum, f) { return sum + f.size; }, 0);
+        return 'Selected ' + files.length + ' files (' + formatBytes(bytes) + ')';
+      }
+      pushFile.addEventListener('change', function () {
+        if (pushFile.files.length) pushFolder.value = '';
+        uploadedBundle = null; pushName.textContent = describePushSelection(); updateButtons();
+      });
+      pushFolder.addEventListener('change', function () {
+        if (pushFolder.files.length) pushFile.value = '';
+        uploadedBundle = null; pushName.textContent = describePushSelection(); updateButtons();
+      });
+      pushDest.addEventListener('input', updateButtons);
+      pushConfirm.addEventListener('change', updateButtons);
+      btnPush.addEventListener('click', sendPush);
       launchPkg.addEventListener('input', updateButtons);
       startupPkg.addEventListener('input', updateButtons);
       btnInstall.addEventListener('click', sendInstall);

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -962,7 +962,15 @@
           uploading = true; nameEl.textContent = 'Uploading ' + files.length + ' file(s)...'; updateButtons();
           return fetch('/api/bundles', { method: 'POST', body: fd })
             .then(function (r) { return r.json().catch(function () { return {}; }).then(function (p) { if (!r.ok) throw new Error(p.error || r.statusText); return p; }); })
-            .then(function (p) { uploaded = p; nameEl.innerHTML = 'Uploaded: <strong>' + esc(p.bundle_filename) + '</strong> (' + p.entry_count + ' file(s), ' + formatBytes(p.size) + ')'; addLog('Uploaded bundle: ' + p.bundle_filename + ' (' + p.entry_count + ' file(s))', 'success'); return p; })
+            .then(function (p) {
+              uploaded = p;
+              nameEl.innerHTML = 'Uploaded: <strong>' + esc(p.bundle_filename) + '</strong> (' + p.entry_count + ' file(s), ' + formatBytes(p.size) + ')';
+              addLog('Uploaded bundle: ' + p.bundle_filename + ' (' + p.entry_count + ' file(s))', 'success');
+              // The picked-file count above the button counts what the OS handed the browser;
+              // the server drops its own metadata. Say so, rather than let the numbers differ.
+              if (p.skipped_count) addLog('Excluded ' + p.skipped_count + ' OS metadata file(s) (e.g. .DS_Store) from the bundle', 'info');
+              return p;
+            })
             .finally(function () { uploading = false; updateButtons(); });
         }
 

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -566,7 +566,7 @@
             // Per-device companion to INSTALL_PROGRESS: the aggregate counts cannot
             // be mapped back to rows, so the server names the devices it moved.
             (msg.device_ids || []).forEach(function (id) {
-              installState[id] = { status: msg.state, filename: msg.apk_filename || '', detail: msg.detail || '' };
+              installState[id] = { task: 'install', status: msg.state, filename: msg.apk_filename || '', detail: msg.detail || '' };
               updateInstallCell(id);
             });
             break;
@@ -574,18 +574,22 @@
           case 'INSTALL_RESULT': {
             const st = msg.status === 'success' ? 'success' : 'fail';
             const detail = msg.error || msg.message || '';
-            if (msg.device_id) { installState[msg.device_id] = { status: st, filename: msg.apk_filename || '', detail: detail }; updateInstallCell(msg.device_id); }
+            if (msg.device_id) { installState[msg.device_id] = { task: 'install', status: st, filename: msg.apk_filename || '', detail: detail }; updateInstallCell(msg.device_id); }
             addLog('[' + (msg.status === 'success' ? 'OK' : 'FAIL') + '] install ' + (msg.apk_filename || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), st);
             break;
           }
           case 'PUSH_FILES_SENT': addLog('Push command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s) → ' + (msg.dest_path || '-'), 'info'); break;
           case 'PUSH_FILES_RESULT': {
             const st = msg.status === 'success' ? 'success' : 'fail';
+            const summary = '+' + (msg.added || 0) + ' ~' + (msg.updated || 0) + ' -' + (msg.deleted || 0);
+            const detail = msg.error || msg.message || '';
+            if (msg.device_id) {
+              installState[msg.device_id] = { task: 'push', status: st, filename: msg.dest_path || '', note: st === 'success' ? summary : '', detail: detail };
+              updateInstallCell(msg.device_id);
+            }
             if (st === 'success') {
-              const summary = '+' + (msg.added || 0) + ' ~' + (msg.updated || 0) + ' -' + (msg.deleted || 0);
               addLog('[OK] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + ' (' + summary + ')', 'success');
             } else {
-              const detail = msg.error || msg.message || '';
               addLog('[FAIL] push to ' + (msg.dest_path || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), 'fail');
             }
             break;
@@ -702,7 +706,7 @@
         let html = '<div class="dev-table">';
         html += '<div class="dev-row dev-head">' +
           '<div class="selbox ' + (allSel ? 'on' : someSel ? 'mixed' : '') + '" data-act="selectAll">' + (allSel ? '✓' : someSel ? '–' : '') + '</div>' +
-          '<div>Device</div><div>Status</div><div>Battery</div><div>Install</div></div>';
+          '<div>Device</div><div>Status</div><div>Battery</div><div>Progress</div></div>';
         devices.forEach(function (d) {
           const id = getDeviceId(d);
           const checked = selectedIds.has(id);
@@ -746,12 +750,22 @@
         return html;
       }
 
-      // The four live states mirror the server's install job: a device waits for a
-      // transfer slot (queued), pulls the APK (transferring), installs it locally
-      // (installing), then reports a terminal INSTALL_RESULT (success/fail).
+      // The cell shows whichever job last touched the device, install or push.
+      //
+      // An install's four live states mirror the server's install job: a device waits
+      // for a transfer slot (queued), pulls the APK (transferring), installs it locally
+      // (installing), then reports a terminal INSTALL_RESULT (success/fail). A push has
+      // no such phases — it is not throttled, so the server holds no per-device state
+      // for it and cannot broadcast transitions. The console paints `pushing` on
+      // dispatch and resolves it on PUSH_FILES_RESULT.
       function installCellHtml(id) {
         const st = installState[id];
         if (!st) return '<span class="ins-none">—</span>';
+        if (st.task === 'push') {
+          if (st.status === 'pushing') return '<span class="ins-installing"><span class="spinner">⟳</span> Pushing…</span>';
+          if (st.status === 'success') return '<span class="ins-success">✓ pushed</span>' + (st.note ? ' <span class="ins-none">' + esc(st.note) + '</span>' : '');
+          return '<span class="ins-fail" title="' + esc(st.detail || '') + '">✗ failed</span>' + (st.detail ? ' <span class="ins-none">' + esc(st.detail) + '</span>' : '');
+        }
         if (st.status === 'queued') return '<span class="ins-queued">◦ Waiting…</span>';
         if (st.status === 'transferring') return '<span class="ins-transferring"><span class="spinner">⟳</span> Transferring…</span>';
         if (st.status === 'installing') return '<span class="ins-installing"><span class="spinner">⟳</span> Installing…</span>';
@@ -870,7 +884,7 @@
           if (!wsSend({ type: 'INSTALL_APK', target_devices: online, apk_url: apk.apk_url, apk_filename: apk.apk_filename }, 'install')) return;
           // Optimistic first paint only: every target really does start out waiting
           // for a transfer slot. The server's INSTALL_DEVICE_STATE drives it from here.
-          online.forEach(function (id) { installState[id] = { status: 'queued', filename: apk.apk_filename, detail: '' }; updateInstallCell(id); });
+          online.forEach(function (id) { installState[id] = { task: 'install', status: 'queued', filename: apk.apk_filename, detail: '' }; updateInstallCell(id); });
           addLog('Installing ' + apk.apk_filename + ' on ' + online.length + ' device(s)', 'info');
           // Force a fresh pick next time (LAN/non-secure context cannot detect a local rebuild).
           apkFile.value = ''; uploadedApk = null; apkName.textContent = 'No APK selected'; updateButtons();
@@ -912,6 +926,10 @@
         if (!online.length) { addLog('No online devices selected to push files', 'warn'); return; }
         ensureBundleUploaded().then(function (bundle) {
           if (!wsSend({ type: 'PUSH_FILES', target_devices: online, bundle_url: bundle.bundle_url, bundle_filename: bundle.bundle_filename, dest_path: dest }, 'push files')) return;
+          // Optimistic first paint: a push is dispatched to every online target at once
+          // (no throttle), so each one really is pushing from here until its
+          // PUSH_FILES_RESULT arrives, or DEVICE_LIST drops it as offline.
+          online.forEach(function (id) { installState[id] = { task: 'push', status: 'pushing', filename: dest, note: '', detail: '' }; updateInstallCell(id); });
           addLog('Pushing ' + bundle.bundle_filename + ' → ' + dest + ' on ' + online.length + ' device(s)', 'info');
           // Force a fresh pick next time (LAN/non-secure context cannot detect a local change).
           resetPushSelection();

--- a/mdm-server/tests/test_push_files.py
+++ b/mdm-server/tests/test_push_files.py
@@ -1,0 +1,284 @@
+"""Tests for the push-files (file/folder full-mirror sync) feature.
+
+Covers the pure path/bundle helpers, the destination-safety guard, the bundle upload
+endpoint (multipart tree -> zip), and the PUSH_FILES command fan-out. No real network is
+used: async handlers run via asyncio.run with in-memory fakes / the aiohttp test client.
+"""
+
+import asyncio
+import json
+import zipfile
+
+import aiohttp
+from aiohttp.test_utils import TestClient, TestServer
+import pytest
+
+import styly_mdm
+from styly_mdm import server
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("a.txt", "a.txt"),
+        ("folder/sub/a.txt", "folder/sub/a.txt"),
+        ("folder\\sub\\a.txt", "folder/sub/a.txt"),   # backslashes normalized
+        ("./a/./b.txt", "a/b.txt"),                    # '.' segments dropped
+        ("/abs/path.txt", "abs/path.txt"),             # leading slash -> relative
+        ("../secret", None),                           # parent traversal rejected
+        ("a/../../b", None),
+        ("", None),
+        ("   ", None),
+        (None, None),
+    ],
+)
+def test_sanitize_relpath(raw, expected):
+    assert server.sanitize_relpath(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "dest",
+    [
+        "/sdcard/STYLY/content",
+        "/storage/emulated/0/STYLY/content",
+        "/sdcard/a",
+        "/sdcard/STYLY/content/",       # trailing slash tolerated
+    ],
+)
+def test_validate_dest_path_accepts_safe(dest):
+    assert server.validate_dest_path(dest) is None
+
+
+@pytest.mark.parametrize(
+    "dest",
+    [
+        "", "   ", None,
+        "relative/path",                 # not absolute
+        "/sdcard",                       # storage root, no subdir
+        "/sdcard/",                      # storage root
+        "/storage/emulated/0",           # storage root
+        "/sdcard/Download",              # protected top-level dir
+        "/sdcard/download/x",            # protected (case-insensitive)
+        "/sdcard/Android/data/x",        # protected
+        "/sdcard/DCIM/x",                # protected
+        "/sdcard/STYLY/../content",      # contains '..'
+        "/etc/passwd",                   # outside shared storage
+    ],
+)
+def test_validate_dest_path_rejects_unsafe(dest):
+    assert server.validate_dest_path(dest) is not None
+
+
+def test_bundle_basename():
+    assert server.bundle_basename(["config.txt"]) == "config"
+    assert server.bundle_basename(["myfolder/a.txt", "myfolder/b.txt"]) == "myfolder"
+    assert server.bundle_basename(["x/a.txt", "y/b.txt"]) == "bundle"
+    assert server.bundle_basename([]) == "bundle"
+
+
+def test_unique_bundle_path_avoids_collision(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    server.BUNDLE_DIR.mkdir(parents=True, exist_ok=True)
+
+    first = server.unique_bundle_path("content.zip")
+    assert first == server.BUNDLE_DIR / "content.zip"
+
+    first.write_bytes(b"x")  # occupy the name
+    second = server.unique_bundle_path("content.zip")
+    assert second != first
+    assert second.name.startswith("content-")
+    assert second.suffix == ".zip"
+
+
+def test_zip_tree_stores_forward_slash_relative_names(tmp_path):
+    root = tmp_path / "src"
+    (root / "sub").mkdir(parents=True)
+    (root / "a.txt").write_bytes(b"AAA")
+    (root / "sub" / "b.txt").write_bytes(b"BBB")
+    dest_zip = tmp_path / "out.zip"
+
+    server.zip_tree(root, dest_zip)
+
+    with zipfile.ZipFile(dest_zip) as z:
+        assert set(z.namelist()) == {"a.txt", "sub/b.txt"}
+        assert z.read("sub/b.txt") == b"BBB"
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+def test_create_app_registers_bundle_routes(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+    method_paths = {(route.method, route.resource.canonical) for route in app.router.routes()}
+    canonicals = {resource.canonical for resource in app.router.resources()}
+    assert ("POST", "/api/bundles") in method_paths
+    assert any(c.startswith("/bundles") for c in canonicals)
+    assert (tmp_path / "bundles").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Bundle upload endpoint (multipart tree -> zip)
+# ---------------------------------------------------------------------------
+
+async def _upload(app, parts):
+    """POST parts (list of (relpath, bytes)) to /api/bundles; return (status, json)."""
+    async with TestClient(TestServer(app)) as client:
+        data = aiohttp.FormData()
+        for relpath, content in parts:
+            data.add_field("files", content, filename=relpath,
+                           content_type="application/octet-stream")
+        resp = await client.post("/api/bundles", data=data)
+        return resp.status, await resp.json()
+
+
+def test_strip_common_root():
+    # Folder pick: shared top dir stripped so the bundle mirrors its contents.
+    assert server.strip_common_root(["myfolder/a.txt", "myfolder/sub/b.txt"]) == (
+        "myfolder", ["a.txt", "sub/b.txt"])
+    # A bare top-level file among the entries -> no shared root, unchanged.
+    assert server.strip_common_root(["a.txt", "b.txt"]) == (None, ["a.txt", "b.txt"])
+    assert server.strip_common_root(["config.json"]) == (None, ["config.json"])
+    # Two distinct roots -> unchanged.
+    assert server.strip_common_root(["x/a.txt", "y/b.txt"]) == (None, ["x/a.txt", "y/b.txt"])
+
+
+def test_upload_bundle_folder_pick_mirrors_contents(tmp_path):
+    # A folder pick nests files under the folder name; the bundle must contain the
+    # folder's *contents* (root stripped) so it mirrors into the destination directly,
+    # while the bundle is still named after the picked folder.
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+
+    status, body = asyncio.run(_upload(app, [
+        ("myfolder/a.txt", b"AAA"),
+        ("myfolder/sub/b.txt", b"BBBBB"),
+    ]))
+
+    assert status == 200
+    assert body["entry_count"] == 2
+    assert body["bundle_filename"].startswith("myfolder")
+    zip_path = server.BUNDLE_DIR / body["bundle_filename"]
+    assert zip_path.is_file()
+    with zipfile.ZipFile(zip_path) as z:
+        assert set(z.namelist()) == {"a.txt", "sub/b.txt"}  # root stripped
+    # The transient staging directory must be cleaned up, leaving only the zip.
+    assert [p.name for p in server.BUNDLE_DIR.iterdir()] == [body["bundle_filename"]]
+
+
+def test_upload_bundle_multiple_files_keep_flat_names(tmp_path):
+    # Multiple individually-picked files share no folder root -> archived as-is.
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+    status, body = asyncio.run(_upload(app, [("a.txt", b"A"), ("b.txt", b"B")]))
+    assert status == 200
+    assert body["entry_count"] == 2
+    with zipfile.ZipFile(server.BUNDLE_DIR / body["bundle_filename"]) as z:
+        assert set(z.namelist()) == {"a.txt", "b.txt"}
+
+
+def test_upload_bundle_single_file(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+    status, body = asyncio.run(_upload(app, [("config.json", b"{}")]))
+    assert status == 200
+    assert body["entry_count"] == 1
+    assert body["bundle_filename"].startswith("config")
+
+
+def test_upload_bundle_rejects_traversal_filename(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+    status, _ = asyncio.run(_upload(app, [("../evil.txt", b"x")]))
+    assert status == 400
+
+
+def test_upload_bundle_requires_files(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+
+    async def _empty():
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/bundles", data=aiohttp.FormData())
+            return resp.status
+
+    assert asyncio.run(_empty()) == 400
+
+
+# ---------------------------------------------------------------------------
+# PUSH_FILES command fan-out
+# ---------------------------------------------------------------------------
+
+class FakeWS:
+    """Captures messages sent to it as parsed dicts."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, text):
+        self.sent.append(json.loads(text))
+
+
+def _register_online_device(did):
+    ws = FakeWS()
+    server.devices[did] = {
+        "ws": ws, "device_id": did, "model": "PICO 4E",
+        "ip": "192.168.1.10", "status": "online", "startup_app": None, "battery": None,
+    }
+    return ws
+
+
+def test_handle_push_files_fans_out_to_online_devices(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    server.devices.clear()
+    dev_ws = _register_online_device("dev-1")
+    admin = FakeWS()
+
+    asyncio.run(server.handle_push_files(admin, {
+        "target_devices": ["*"],
+        "bundle_url": "http://host/bundles/b.zip",
+        "bundle_filename": "b.zip",
+        "dest_path": "/sdcard/STYLY/content",
+    }))
+
+    assert dev_ws.sent[0]["type"] == "EXECUTE_PUSH_FILES"
+    assert dev_ws.sent[0]["bundle_url"] == "http://host/bundles/b.zip"
+    assert dev_ws.sent[0]["dest_path"] == "/sdcard/STYLY/content"
+
+    sent_ack = admin.sent[-1]
+    assert sent_ack["type"] == "PUSH_FILES_SENT"
+    assert sent_ack["sent_count"] == 1
+    assert sent_ack["target_count"] == 1
+    assert sent_ack["dest_path"] == "/sdcard/STYLY/content"
+
+
+def test_handle_push_files_rejects_unsafe_dest(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    server.devices.clear()
+    dev_ws = _register_online_device("dev-1")
+    admin = FakeWS()
+
+    asyncio.run(server.handle_push_files(admin, {
+        "target_devices": ["*"],
+        "bundle_url": "http://host/bundles/b.zip",
+        "bundle_filename": "b.zip",
+        "dest_path": "/sdcard/Download",   # protected -> must be rejected
+    }))
+
+    assert admin.sent[-1]["type"] == "ERROR"
+    assert dev_ws.sent == []  # nothing dispatched to the device
+
+
+def test_handle_push_files_requires_bundle_url(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    server.devices.clear()
+    admin = FakeWS()
+    asyncio.run(server.handle_push_files(admin, {
+        "target_devices": ["*"], "dest_path": "/sdcard/STYLY/content",
+    }))
+    assert admin.sent[-1]["type"] == "ERROR"

--- a/mdm-server/tests/test_push_files.py
+++ b/mdm-server/tests/test_push_files.py
@@ -257,6 +257,40 @@ def test_handle_push_files_fans_out_to_online_devices(tmp_path):
     assert sent_ack["dest_path"] == "/sdcard/STYLY/content"
 
 
+@pytest.mark.parametrize(
+    "sent_value, expected",
+    [
+        # A push (copy) and an explicit sync (mirror) round-trip their flag verbatim.
+        (False, False),
+        (True, True),
+        # Everything else must decode to "do not delete". An omitted field is the case that
+        # matters most: a console that predates the flag must never trigger a mirror.
+        (None, False),
+        ("true", False),
+        (1, False),
+    ],
+)
+def test_handle_push_files_only_a_literal_true_requests_deletion(tmp_path, sent_value, expected):
+    server._apply_data_dir(str(tmp_path))
+    server.devices.clear()
+    dev_ws = _register_online_device("dev-1")
+    admin = FakeWS()
+
+    data = {
+        "target_devices": ["*"],
+        "bundle_url": "http://host/bundles/b.zip",
+        "bundle_filename": "b.zip",
+        "dest_path": "/sdcard/STYLY/content",
+    }
+    if sent_value is not None:
+        data["delete_extras"] = sent_value
+
+    asyncio.run(server.handle_push_files(admin, data))
+
+    assert dev_ws.sent[0]["delete_extras"] is expected
+    assert admin.sent[-1]["delete_extras"] is expected
+
+
 def test_handle_push_files_rejects_unsafe_dest(tmp_path):
     server._apply_data_dir(str(tmp_path))
     server.devices.clear()

--- a/mdm-server/tests/test_push_files.py
+++ b/mdm-server/tests/test_push_files.py
@@ -148,6 +148,80 @@ def test_strip_common_root():
     assert server.strip_common_root(["x/a.txt", "y/b.txt"]) == (None, ["x/a.txt", "y/b.txt"])
 
 
+@pytest.mark.parametrize("relpath", [
+    ".DS_Store",
+    "sub/.DS_Store",
+    "sub/.ds_store",                       # case-insensitive
+    "._resourcefork.txt",                  # AppleDouble sidecar
+    "sub/._a.txt",
+    "Thumbs.db",
+    "sub/thumbs.db",
+    "ehthumbs.db",
+    "desktop.ini",
+    ".directory",
+    ".apdisk",
+    ".VolumeIcon.icns",
+    ".Spotlight-V100/store.db",            # excluded via the directory segment
+    ".Trashes/501/x",
+    ".fseventsd/000",
+    ".TemporaryItems/a",
+    ".DocumentRevisions-V100/a",
+    "__MACOSX/._a.txt",
+    "$RECYCLE.BIN/a",
+    ".Trash-1000/files/a",                 # Linux per-user trash on removable media
+])
+def test_is_excluded_bundle_entry_matches_os_metadata(relpath):
+    assert server.is_excluded_bundle_entry(relpath) is True
+
+
+@pytest.mark.parametrize("relpath", [
+    "a.txt",
+    "sub/b.bin",
+    ".gitignore",                          # a dotfile the user authored stays
+    ".git/config",                         # VCS is deliberately NOT excluded
+    "scene.unity.meta",                    # Unity metadata is real content here
+    "_underscore.txt",                     # only "._" prefixes are AppleDouble
+    "my.DS_Store.txt",                     # substring, not the whole segment
+    "desktop.ini.bak",
+])
+def test_is_excluded_bundle_entry_keeps_real_content(relpath):
+    assert server.is_excluded_bundle_entry(relpath) is False
+
+
+def test_upload_bundle_drops_os_metadata_and_reports_the_count(tmp_path):
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+
+    status, body = asyncio.run(_upload(app, [
+        ("myfolder/a.txt", b"AAA"),
+        ("myfolder/.DS_Store", b"junk"),
+        ("myfolder/sub/b.txt", b"BBBBB"),
+        ("myfolder/sub/.DS_Store", b"junk"),
+        ("myfolder/sub/._b.txt", b"junk"),
+    ]))
+
+    assert status == 200
+    assert body["entry_count"] == 2
+    assert body["skipped_count"] == 3
+    with zipfile.ZipFile(server.BUNDLE_DIR / body["bundle_filename"]) as z:
+        assert set(z.namelist()) == {"a.txt", "sub/b.txt"}
+
+
+def test_upload_bundle_rejects_an_upload_that_is_only_os_metadata(tmp_path):
+    # Excluding everything must fail loudly rather than build an empty bundle that a
+    # Sync Folder would then use to wipe the destination.
+    server._apply_data_dir(str(tmp_path))
+    app = styly_mdm.create_app()
+
+    status, body = asyncio.run(_upload(app, [
+        ("myfolder/.DS_Store", b"junk"),
+        ("myfolder/sub/._a.txt", b"junk"),
+    ]))
+
+    assert status == 400
+    assert "OS metadata" in body["error"]
+
+
 def test_upload_bundle_folder_pick_mirrors_contents(tmp_path):
     # A folder pick nests files under the folder name; the bundle must contain the
     # folder's *contents* (root stripped) so it mirrors into the destination directly,


### PR DESCRIPTION
Closes #4.

Adds the ability to send files or a whole folder from the console to a directory on selected devices.

## Two actions, not one

The original implementation had a single "Push Files" action with full-mirror semantics: whatever was at the destination and not in the upload got deleted. That is correct for "make this folder match" and plainly wrong for "put this file on the device" — so it is now two actions.

| Console action | `delete_extras` | Semantics |
|---|---|---|
| **Push Files** (file or folder) | `false` | Copy and overwrite. Nothing at the destination is removed. |
| **Sync Folder** (folder only) | `true` | Full mirror: extras are deleted, so the destination ends up identical to the bundle (`rsync --delete`). |

Two panels rather than one panel with a delete toggle: the destructive operation has to be chosen **by name**. Only Sync Folder carries the warning and its confirmation checkbox.

The delete lives in exactly one place — `BundleSync.apply` in the client, gated on `deleteExtras`. The server only passes the flag through. Both boundaries decode it defensively (`data.get("delete_extras") is True` on the server, `optBoolean(..., false)` on the client), so a missing or malformed field can only ever copy, and a console that predates the flag cannot trigger a mirror.

## How it works

The console uploads to `POST /api/bundles`; the server rebuilds the folder tree from each part's `webkitRelativePath`, zips it, and serves it from `/bundles/`. `PUSH_FILES` fans out `EXECUTE_PUSH_FILES` to the targets, each of which downloads the bundle, unzips it (with a zip-slip guard), and applies it.

**Destination safety.** A mirror deletes, and the PICO ToBService exposes no privileged file-copy API, so both actions are constrained identically on the server (syntactic) and the client (canonical): the destination must be under shared storage (`/sdcard`), and may be neither the storage root nor a protected top-level directory (`Android`, `Download`, `DCIM`, `Pictures`, …). App-scoped `Android/data/<pkg>/` is not reachable via `java.io.File` I/O and so is not targetable.

**OS metadata is excluded.** A folder pick drags along a `.DS_Store` per directory, an `._name` AppleDouble sidecar per file once the folder has been through a USB stick, plus `Thumbs.db` / `desktop.ini` / `.Spotlight-V100/` / `__MACOSX/` / `$RECYCLE.BIN/` / `.Trash-*/`. These are dropped before anything is written to staging, so they never reach the zip and never land on a device. `.git/`, Unity `.meta`, and dotfiles at large are uploaded as-is — silently dropping authored content would be a worse failure than shipping an unwanted `.DS_Store`. An upload that is *entirely* metadata is rejected with 400 rather than producing an empty bundle, which a Sync Folder would then use to wipe the destination.

**Progress.** The device table's per-device state column was install-only; it now reports pushes too, and is renamed INSTALL → PROGRESS. Push states are painted client-side rather than broadcast by the server: install's queued/transferring/installing transitions exist because the server owns transfer slots for throttling, but push is not throttled and the server holds no per-device state for it. The console paints `Pushing…` / `Syncing…` on dispatch and resolves it on `PUSH_FILES_RESULT`.

## Deployment note

The delete is client-side, so the non-destructive Push only exists on devices running an APK that includes this change. **An older client mirrors whatever it is sent.** Roll out the client before relying on Push being safe.

## Testing

- `mdm-server`: 110 passing (`python -m pytest`). Covers `delete_extras` passthrough (`False` / `True` / omitted / `"true"` / `1` — only a literal `true` requests deletion), the exclusion list, and the empty-after-exclusion rejection. The exclusion integration test interleaves `.DS_Store` between real files, so a skipped multipart part that failed to drain would corrupt the following file.
- `mdm-client`: adds the client's first unit tests (`./gradlew :app:testProdDebugUnitTest`). `BundleSync` is extracted out of the Service and kept free of Android imports so its copy-vs-mirror branches are provable on the host JVM. Removing the `deleteExtras` gate makes `BundleSyncTest` fail, so the tests have teeth.
- Manual: drove Push, Sync, and a regression Install through the real console against a live server and a stub device. Verified the device receives `delete_extras=false` then `true`, that a 6-file folder with 4 metadata files yields a 2-entry bundle with `Excluded 4 …` logged, and that the PROGRESS column shows `⟳ Pushing… → ✓ pushed` / `⟳ Syncing… → ✓ synced` / `⟳ Transferring… → ⟳ Installing… → ✓ installed`. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)