### PR TITLE
docs: document server startup options and how to migrate to another server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,29 @@ The server starts on port 7070 and displays its LAN IP addresses:
 
 Open `http://<server-ip>:7070` in a browser to access the web console.
 
-**Configuration** — all optional:
+**Configuration** — all optional. A command-line flag overrides the corresponding environment variable.
 
 | Setting | Env var | Flag | Default |
 |---------|---------|------|---------|
 | HTTP/WebSocket port | `MDM_WS_PORT` | `--port` | `7070` |
 | UDP discovery port | `MDM_DISCOVERY_PORT` | — | `7071` |
 | Data directory (uploaded APKs + device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
+| Simultaneous APK transfers per install job | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
+| Seconds a device may hold a transfer slot | `MDM_TRANSFER_TIMEOUT` | — | `600` |
+
+The **data directory** holds everything the server persists: uploaded APKs (`apks/`), pushed file bundles (`bundles/`), and the device registry (`device_registry.json`). It defaults to the directory the server is started from, so `uvx styly-mdm` in a fresh directory comes up with no devices or groups. Pass `--data-dir` to pin it somewhere stable.
+
+**Transfer throttling** keeps a large install job from making every device pull the APK at the same instant (an APK can be up to 2 GiB). At most `--max-concurrent-transfers` devices download at once; the rest queue, and a slot frees as soon as its device reports the download finished. `MDM_TRANSFER_TIMEOUT` caps how long one device may hold a slot, so a stuck device cannot block the queue. The [Developer Guide](docs/DEVELOPMENT.md) documents the full slot-release rules.
+
+> **Only one server per discovery port.** Devices connect to whichever server answers discovery first, so two servers sharing a discovery port would split them nondeterministically. To prevent that, the server broadcasts a probe on startup and exits if another STYLY-MDM server answers:
+>
+> ```
+> [ERROR] Another STYLY-MDM server is already running on this network and
+> responding on discovery port 7071 (from 192.168.1.42). Refusing to start so
+> devices cannot connect to the wrong server.
+> ```
+>
+> To run a development server alongside production, give it its own ports — `mdm-server/run.sh dev` does this by setting `MDM_DISCOVERY_PORT=7081` and `MDM_WS_PORT=7080`. The probe is best-effort: two servers started at the same instant can miss each other.
 
 ### 2. Configure the MDM Client
 
@@ -114,7 +130,7 @@ Uploaded APKs are stored under `<data-dir>/apks/` (the data directory defaults t
 
 Device labels and group definitions live in a single file, `<data-dir>/device_registry.json`. Moving them to another machine is a file copy — there is no export step in the console.
 
-1. **Stop the old server, and make sure the new one is not running yet.** A running server owns the registry file: every label edit, group change, and battery report rewrites it from in-memory state, so a file dropped in underneath a live server is silently overwritten. Leaving the old server up also keeps it answering UDP discovery, and devices will bounce between the two.
+1. **Stop the old server, and make sure the new one is not running yet.** A running server owns the registry file: every label edit, group change, and battery report rewrites it from in-memory state, so a file dropped in underneath a live server is silently overwritten. The old server has to go down anyway — while it is still answering discovery on the same port, the new one refuses to start (see [Configuration](#1-start-the-control-server)).
 
 2. **Copy the registry into the new server's data directory.**
 

--- a/README.md
+++ b/README.md
@@ -68,20 +68,21 @@ Open `http://<server-ip>:7070` in a browser to access the web console.
 |---------|---------|------|---------|
 | HTTP/WebSocket port | `MDM_WS_PORT` | `--port` | `7070` |
 | UDP discovery port | `MDM_DISCOVERY_PORT` | — | `7071` |
-| Data directory (uploaded APKs + device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
-| Simultaneous APK transfers per install job | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
+| Data directory (uploaded APKs, pushed bundles, device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
+| Simultaneous device downloads, server-wide | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
 | Seconds a device may hold a transfer slot | `MDM_TRANSFER_TIMEOUT` | — | `600` |
 
 The **data directory** holds everything the server persists: uploaded APKs (`apks/`), pushed file bundles (`bundles/`), and the device registry (`device_registry.json`). It defaults to the directory the server is started from, so `uvx styly-mdm` in a fresh directory comes up with no devices or groups. Pass `--data-dir` to pin it somewhere stable.
 
-**Transfer throttling** keeps a large install job from making every device pull the APK at the same instant (an APK can be up to 2 GiB). At most `--max-concurrent-transfers` devices download at once; the rest queue, and a slot frees as soon as its device reports the download finished. `MDM_TRANSFER_TIMEOUT` caps how long one device may hold a slot, so a stuck device cannot block the queue. The [Developer Guide](docs/DEVELOPMENT.md) documents the full slot-release rules.
+**Transfer throttling** keeps a large fan-out — an APK install, a file push, or a folder sync — from making every device download at the same instant (an APK or a pushed bundle can be up to 2 GiB). All jobs share one server-wide pool: at most `--max-concurrent-transfers` devices download at once; the rest queue, and a slot frees as soon as its device reports the download finished. `MDM_TRANSFER_TIMEOUT` caps how long one device may hold a slot, so a stuck device cannot block the queue. The [Developer Guide](docs/DEVELOPMENT.md) documents the full slot-release rules.
 
 > **Only one server per discovery port.** Devices connect to whichever server answers discovery first, so two servers sharing a discovery port would split them nondeterministically. To prevent that, the server broadcasts a probe on startup and exits if another STYLY-MDM server answers:
 >
 > ```
 > [ERROR] Another STYLY-MDM server is already running on this network and
 > responding on discovery port 7071 (from 192.168.1.42). Refusing to start so
-> devices cannot connect to the wrong server.
+> devices cannot connect to the wrong server. Stop the other server, or set
+> MDM_DISCOVERY_PORT to a different value to run alongside it.
 > ```
 >
 > To run a development server alongside production, give it its own ports — `mdm-server/run.sh dev` does this by setting `MDM_DISCOVERY_PORT=7081` and `MDM_WS_PORT=7080`. The probe is best-effort: two servers started at the same instant can miss each other.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ Uploaded APKs are stored under `<data-dir>/apks/` (the data directory defaults t
 >
 > (or toggle **All files access** for the app in the headset's app settings). The client's own settings screen also shows the current grant status and a **Grant All Files Access** button that opens this settings page. Without it, installs fail with `pbsControlAPPManger returned 102: APK does not exist`.
 
+## Migrating to Another Server
+
+Device labels and group definitions live in a single file, `<data-dir>/device_registry.json`. Moving them to another machine is a file copy — there is no export step in the console.
+
+1. **Stop the old server, and make sure the new one is not running yet.** A running server owns the registry file: every label edit, group change, and battery report rewrites it from in-memory state, so a file dropped in underneath a live server is silently overwritten. Leaving the old server up also keeps it answering UDP discovery, and devices will bounce between the two.
+
+2. **Copy the registry into the new server's data directory.**
+
+   ```bash
+   scp old-host:/path/to/mdm-server/device_registry.json new-host:/srv/styly-mdm/
+   ```
+
+3. **Start the new server pointed at that directory.**
+
+   ```bash
+   styly-mdm --data-dir /srv/styly-mdm
+   ```
+
+Devices rediscover the new server over UDP and reconnect on their own. The `ip` and `last_seen` fields refresh on reconnect, and group membership is keyed by serial number, so devices that are offline during the move keep their groups.
+
+Uploaded APKs (`<data-dir>/apks/`) and pushed file bundles (`<data-dir>/bundles/`) are not part of the registry. Copy those directories separately with `rsync` or `scp` if the new server needs them — a single APK can be up to 2 GiB, so they are not worth moving through a browser.
+
 ## Documentation
 
 - **[Developer Guide](docs/DEVELOPMENT.md)** — architecture, build instructions, project structure, WebSocket / discovery protocol references, client permissions, and version requirements.

--- a/mdm-server/README.md
+++ b/mdm-server/README.md
@@ -33,8 +33,8 @@ A command-line flag overrides the corresponding environment variable.
 |--------|---------|------|---------|
 | HTTP/WebSocket port | `MDM_WS_PORT` | `--port` | `7070` |
 | UDP discovery port | `MDM_DISCOVERY_PORT` | — | `7071` |
-| Data directory (uploaded APKs + device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
-| Simultaneous APK transfers per install job | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
+| Data directory (uploaded APKs, pushed bundles, device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
+| Simultaneous device downloads, server-wide | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
 | Seconds a device may hold a transfer slot | `MDM_TRANSFER_TIMEOUT` | — | `600` |
 
 The data directory holds everything the server persists: uploaded APKs
@@ -43,8 +43,9 @@ registry (`<data-dir>/device_registry.json`). It defaults to the directory the
 server is started from, so `uvx styly-mdm` in a fresh directory comes up with no
 devices or groups.
 
-Transfer throttling bounds how many devices download an APK at once during a
-single install job; the rest queue until a slot frees.
+Transfer throttling bounds how many devices download at once — one server-wide
+pool shared by every install and push/sync job; the rest queue until a slot
+frees.
 
 Only one server may answer discovery on a given port: the server probes on
 startup and exits if another STYLY-MDM server already responds on its discovery

--- a/mdm-server/README.md
+++ b/mdm-server/README.md
@@ -27,14 +27,29 @@ discover the server automatically via UDP broadcast (port **7071**).
 
 ## Configuration
 
+A command-line flag overrides the corresponding environment variable.
+
 | Option | Env var | Flag | Default |
 |--------|---------|------|---------|
 | HTTP/WebSocket port | `MDM_WS_PORT` | `--port` | `7070` |
 | UDP discovery port | `MDM_DISCOVERY_PORT` | — | `7071` |
 | Data directory (uploaded APKs + device registry) | `MDM_DATA_DIR` | `--data-dir` | current directory |
+| Simultaneous APK transfers per install job | `MDM_MAX_CONCURRENT_TRANSFERS` | `--max-concurrent-transfers` | `5` |
+| Seconds a device may hold a transfer slot | `MDM_TRANSFER_TIMEOUT` | — | `600` |
 
-Uploaded APKs are written to `<data-dir>/apks/` and the persistent device
-registry to `<data-dir>/device_registry.json`.
+The data directory holds everything the server persists: uploaded APKs
+(`<data-dir>/apks/`), pushed file bundles (`<data-dir>/bundles/`), and the device
+registry (`<data-dir>/device_registry.json`). It defaults to the directory the
+server is started from, so `uvx styly-mdm` in a fresh directory comes up with no
+devices or groups.
+
+Transfer throttling bounds how many devices download an APK at once during a
+single install job; the rest queue until a slot frees.
+
+Only one server may answer discovery on a given port: the server probes on
+startup and exits if another STYLY-MDM server already responds on its discovery
+port. Run a second server alongside the first by giving it a different
+`MDM_DISCOVERY_PORT` and `MDM_WS_PORT`.
 
 You can also start it as a module: `python -m styly_mdm`.
 


### PR DESCRIPTION
## Why

Two gaps in the operator-facing docs, both found while answering "how do I move device and group definitions to another server?"

1. **No migration procedure.** The READMEs said *where* `device_registry.json` lives, but never how to move it. The one constraint that makes a naive copy fail — a running server rewrites the file from in-memory state on every label/group/battery change — was buried in `DEVELOPMENT.md` as an aside about the dummy-device seeding script, where no operator would look.

2. **Incomplete startup options.** Both configuration tables listed three of the five knobs. The transfer throttle (`MDM_MAX_CONCURRENT_TRANSFERS` / `--max-concurrent-transfers`) and the slot timeout (`MDM_TRANSFER_TIMEOUT`, env-only) appeared only in `DEVELOPMENT.md`. So did the startup probe that refuses to boot a second server on an occupied discovery port — an error an operator will actually hit.

## What changed

- `README.md`: new **Migrating to Another Server** section (stop → copy → start with `--data-dir`), plus an expanded **Configuration** block covering all five options, the data directory contents, transfer throttling, and the one-server-per-discovery-port guard with its real error output.
- `mdm-server/README.md`: same two table rows and a condensed version of the guard, keeping the PyPI page short per its own "full documentation lives in the repository" pointer.

Docs only; no code changes.

## Notes

- Every option, default, and behavior was read off `styly_mdm/server.py` on `develop` (`main()`, `probe_existing_server()`, the module-level `MDM_*` reads) and cross-checked against `DEVELOPMENT.md`, which already documented the same numbers (5, 600).
- `styly-mdm hash` is still **not** documented here: it was `feat/verify-integrity-issue-37`-only when this PR was opened and has since landed on `develop` (#47). It belongs with the integrity-verification docs, so documenting it for operators is left to a follow-up.
- Commit `6c23270` corrects a claim introduced in `7a3bc74`: two servers left running together do not make devices bounce between them, `probe_existing_server()` makes the second one exit non-zero. Same advice, accurate reason.
- Commit `e66f2ef` catches the docs up with #46, which merged after this PR was opened and turned the per-install-job slot pool into one server-wide pool shared with push/sync jobs. It also quotes the startup-probe error in full — the previously omitted final sentence carries the actual remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
