### PR TITLE
feat: verify installed APK / directory integrity against a local reference (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ STYLY-MDM currently supports PICO devices (PICO OS with Business Mode). Support 
 - **APK deployment** — upload an APK from the web console and install it silently on selected online devices
 - **File/folder push** — upload a file or an entire folder and copy it into a directory on selected devices; existing files of the same name are overwritten, nothing else at the destination is touched
 - **Folder sync** — mirror a folder into a directory on selected devices, so the destination matches it exactly (new files added, changed files overwritten, **extras removed**). Requires an explicit confirmation, since it deletes. Both actions are limited to shared storage (`/sdcard`)
+- **Integrity verification** — on demand, check that an installed APK (or a shared-storage directory) on selected devices matches a local reference; the reference is hashed in your browser (or via the `styly-mdm hash` CLI) with no upload and no HTTPS requirement, and each device shows a ✓/✗ match
 - **Auto-terminate on switch** — the current foreground app is force-stopped before launching a new one, preventing resource conflicts
 - **Server discovery** — devices can automatically find the MDM server on the LAN via UDP broadcast (port 7071), eliminating manual URL entry
 - **IP address display** — the server logs its LAN IP addresses on startup so you know exactly where to connect

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -360,8 +360,10 @@ STYLY-MDM/
 > `PUSH_FILES_RESULT`; a device that drops offline mid-job clears its cell on the next
 > `DEVICE_LIST`. `PUSH_FILES_RESULT` does not name the mode, so the console carries the
 > verb over from what it dispatched (a page reloaded mid-job falls back to "pushed").
-> The column holds one state per device, so a push and an install targeting the same
-> device overwrite each other's cell — the last job dispatched wins.
+> The column holds one state per device, so a push, an install and a verify targeting the
+> same device overwrite each other's cell — the last job dispatched wins. That state lives
+> in `deviceTaskState[id] = {task, status, …}` and is painted by `taskCellHtml()`; the log
+> keeps the full history of every job regardless.
 
 ## Integrity Verification
 
@@ -372,6 +374,13 @@ client-side**; the server only relays the `VERIFY_*` messages (it never hashes).
 This keeps two hard constraints: a 1 GB+ APK is **never uploaded** just to be
 checked, and no HTTPS/secure-context is required — the browser hashing is pure JS
 (`crypto.subtle` is unavailable over plain `http://<LAN-IP>`).
+
+Verdicts appear in the same per-device **PROGRESS column** as install and push
+(`⟳ Verifying…` → `✓ match` / `✗ mismatch` / `✗ not found` / `✗ error`), so the mismatching
+headset is identified in the device row rather than in a separate list. The column is too
+narrow for `missing 3 · added 0 · changed 1`, so that detail is carried in the cell's
+`title` tooltip and written to the log, which keeps every verdict even after a later job
+overwrites the cell.
 
 The reference, browser, and device implementations must agree byte-for-byte, so
 the algorithms below are a fixed spec (the canonical Python implementation is

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -389,6 +389,18 @@ returns `full_sha256` (whole-file, hardware-accelerated), `version_code`,
 diagnostics shown on a mismatch. ZIP64 archives (CD offset sentinel `0xFFFFFFFF`) are
 not supported and return a clear error rather than a wrong range.
 
+Picking a reference APK also **auto-fills the package name** to verify. The console
+reads `AndroidManifest.xml` out of the picked file (Central Directory → Local File
+Header → stored as-is or inflated with `DecompressionStream('deflate-raw')`, which,
+unlike `crypto.subtle`, works on a non-secure origin) and parses the binary AXML for
+the `<manifest>` element's `package` and `versionName`. Both storage forms occur in
+practice: Unity release APKs store the manifest, Gradle debug APKs deflate it, and the
+AXML string pool may be UTF-8 or UTF-16. This is a progressive enhancement — on any
+parse failure the console logs a warning and the field falls back to manual entry.
+A name the operator typed is never overwritten by a failed parse, but one the console
+filled in from a *previous* APK is cleared, so a reference can never be verified
+against a stale package name.
+
 *Known limitation (accepted):* `size` + CD digest does not detect in-place data
 corruption that preserves the stored CRC-32 (ZIP CRCs are build-time constants). This
 is rare — Android verifies the APK signature at install. `full_sha256` is already

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -141,7 +141,8 @@ STYLY-MDM/
 │   ├── styly_mdm/           # Installable package
 │   │   ├── __init__.py      # Exports create_app / main
 │   │   ├── __main__.py      # `python -m styly_mdm` entrypoint
-│   │   ├── server.py        # WebSocket control server (aiohttp)
+│   │   ├── server.py        # WebSocket control server (aiohttp) + `styly-mdm hash` CLI
+│   │   ├── integrity.py     # APK CD-digest + directory tree-hash (integrity reference)
 │   │   └── static/
 │   │       └── index.html   # Web management console (bundled package data)
 │   └── tests/
@@ -170,6 +171,8 @@ STYLY-MDM/
 | `INSTALL_RESULT` | Result of an APK install. Fields: `status` (`success`/`fail`), `apk_filename`, `result_code` (optional), `error` (optional) |
 | `DOWNLOAD_COMPLETE` | Sent right after the APK download finishes (before the local install). Frees the server's transfer slot so the next queued device can start downloading. Fields: `apk_filename`. Optional — see the install-throttling note below. |
 | `PUSH_FILES_RESULT` | Result of a push or sync. Fields: `status` (`success`/`fail`), `dest_path`, `added`, `updated`, `deleted` (counts; `deleted` is always 0 for a push), `error` (optional) |
+| `VERIFY_APK_RESULT` | Result of an APK integrity check. Fields: `package_name`, `found` (boolean), `size`, `cd_sha256`, `full_sha256`, `version_code`, `version_name`, `signer_sha256`, `error` (optional). Absent hash/version fields when `found` is false. |
+| `VERIFY_DIR_RESULT` | Result of a directory integrity check. Fields: `path`, `found` (boolean), `tree_hash`, `file_count`, `total_size`, `manifest` (optional array of `{relative_path, size, sha256}`, omitted above a cap), `error` (optional) |
 
 ### Server → Device
 
@@ -178,6 +181,8 @@ STYLY-MDM/
 | `EXECUTE_LAUNCH` | Launch an app. Fields: `package_name`, `extra` |
 | `EXECUTE_INSTALL` | Download and install an APK. Fields: `apk_url`, `apk_filename` |
 | `EXECUTE_PUSH_FILES` | Download a bundle and apply it to a directory. Fields: `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean; `false` = copy/overwrite only, `true` = full mirror. Read with a `false` default — a missing field must never delete) |
+| `EXECUTE_VERIFY_APK` | Compute `size` + Central-Directory digest (plus diagnostics) for an installed package. Fields: `package_name` |
+| `EXECUTE_VERIFY_DIR` | Compute a manifest + tree hash for a device directory (shared storage only). Fields: `path` |
 
 ### Admin → Server
 
@@ -186,6 +191,8 @@ STYLY-MDM/
 | `LAUNCH_APP` | Launch an app on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `package_name`, `extra_data` |
 | `INSTALL_APK` | Install an uploaded APK on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `apk_url`, `apk_filename` |
 | `PUSH_FILES` | Apply a bundle to a directory on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean, optional; only a literal `true` requests a full mirror) |
+| `VERIFY_APK` | Verify an installed package against a local reference on target devices. Fields: `target_devices`, `package_name`. The reference (`size` + CD digest) is computed and compared in the browser and is **never** sent to the server. |
+| `VERIFY_DIR` | Verify a device directory against a local reference on target devices. Fields: `target_devices`, `path` (absolute, within shared storage). |
 | `GET_DEVICE_LIST` | Request the current device list |
 | `CREATE_GROUP` | Create a new, empty device group. Fields: `name` |
 | `RENAME_GROUP` | Rename a group, preserving its members. Fields: `name`, `new_name` |
@@ -215,6 +222,9 @@ STYLY-MDM/
 | `PUSH_FILES_RESULT` | Forwarded file/folder result from a device (adds `device_id`) |
 | `LAUNCH_RESULT` | Forwarded result from a device |
 | `INSTALL_RESULT` | Forwarded install result from a device |
+| `VERIFY_SENT` | Confirmation that verify-APK commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
+| `VERIFY_DIR_SENT` | Confirmation that verify-directory commands were dispatched. Fields: `path`, `sent_count`, `target_count` |
+| `VERIFY_APK_RESULT` / `VERIFY_DIR_RESULT` | Forwarded integrity result from a device (stamped with `device_id`). The console compares it against the local reference. |
 | `GROUP_LIST` | Current device groups. Fields: `groups` (object mapping group name → array of member serials). The console derives each device's group membership from this; sent on connect and after any group change. |
 | `GROUP_CREATED` / `GROUP_RENAMED` / `GROUP_DELETED` | Acknowledgements for group create / rename / delete. |
 | `DEVICE_GROUPS_SET` | Acknowledgement of a device's group membership change. Fields: `device_id`, `groups` |
@@ -353,6 +363,64 @@ STYLY-MDM/
 > The column holds one state per device, so a push and an install targeting the same
 > device overwrite each other's cell — the last job dispatched wins.
 
+## Integrity Verification
+
+On-demand check that a package (or a directory) on a managed device matches a
+reference the operator holds locally. The **reference is computed client-side**
+(in the browser, or with the `styly-mdm hash` CLI) and the **comparison happens
+client-side**; the server only relays the `VERIFY_*` messages (it never hashes).
+This keeps two hard constraints: a 1 GB+ APK is **never uploaded** just to be
+checked, and no HTTPS/secure-context is required — the browser hashing is pure JS
+(`crypto.subtle` is unavailable over plain `http://<LAN-IP>`).
+
+The reference, browser, and device implementations must agree byte-for-byte, so
+the algorithms below are a fixed spec (the canonical Python implementation is
+`mdm-server/styly_mdm/integrity.py`).
+
+**APK (`VERIFY_APK`) — `size` + Central-Directory digest.** An APK is a ZIP; its
+tail holds the Central Directory (every entry's CRC-32 + sizes). `cd_sha256` is the
+SHA-256 of `file[CD_offset .. EOF]`, where `CD_offset` is the little-endian uint32 at
+offset 16 of the End-Of-Central-Directory record (the last `PK\x05\x06` whose
+`position + 22 + comment_length == file_length`). This covers every entry while
+reading only a few hundred KB regardless of APK size. A device match requires
+`found && size == reference.size && cd_sha256 == reference.cd_sha256`. The device also
+returns `full_sha256` (whole-file, hardware-accelerated), `version_code`,
+`version_name`, and `signer_sha256` (SHA-256 of the current signing certificate) as
+diagnostics shown on a mismatch. ZIP64 archives (CD offset sentinel `0xFFFFFFFF`) are
+not supported and return a clear error rather than a wrong range.
+
+*Known limitation (accepted):* `size` + CD digest does not detect in-place data
+corruption that preserves the stored CRC-32 (ZIP CRCs are build-time constants). This
+is rare — Android verifies the APK signature at install. `full_sha256` is already
+returned for a future byte-exact "strict" mode. Phase 1 targets the single `base.apk`
+(`sourceDir`); split-APK combination is a possible future extension.
+
+**Directory (`VERIFY_DIR`) — manifest + tree hash.** For each regular file the device
+records `{relative_path, size, sha256}` (paths forward-slashed, relative to the target
+directory), sorts entries by the **UTF-8 byte order** of `relative_path`, and hashes
+`relative_path + "\n" + size + "\n" + sha256 + "\n"` per entry into a single `tree_hash`.
+The console compares `tree_hash` for same/different and, when both manifests are present,
+diffs them to list missing / added / changed files. Policy (identical across all
+implementations): symlinks are not followed and are excluded, empty directories are not
+represented, and an unreadable file makes the whole result an error. Directory checks are
+bounded to **shared external storage** (`/sdcard`), which is what `MANAGE_EXTERNAL_STORAGE`
+grants; the device canonicalizes the path and refuses anything outside that root. Large
+trees can omit the per-file `manifest` (a cap on entry count) and still compare by
+`tree_hash`. Note that OS-generated hidden files in a reference folder (e.g. macOS
+`.DS_Store`, `Thumbs.db`) are hashed as content and will show up as spurious "added"
+entries against a device that does not have them — prune them from the reference first.
+
+**Generating a reference.** In the console, pick a local `.apk` (Verify APK) or a folder
+(Verify Directory) — it is hashed in the browser, never uploaded. For large trees the
+`styly-mdm hash <path>` CLI is faster and deterministic; it prints the same JSON the
+console consumes and runs on the machine that holds the tree (which may differ from the
+server host):
+
+```bash
+styly-mdm hash ./content            # directory -> {tree_hash, file_count, total_size, manifest}
+styly-mdm hash ./app-release.apk    # APK       -> {size, cd_sha256}
+```
+
 ## Server Discovery Protocol
 
 STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.
@@ -400,7 +468,8 @@ The MDM client requires the following Android permissions:
 | `RECEIVE_BOOT_COMPLETED` | Auto-start on device boot |
 | `ACCESS_NETWORK_STATE` | Monitor network connectivity |
 | `ACCESS_WIFI_STATE` | Retrieve the device IP address |
-| `MANAGE_EXTERNAL_STORAGE` | Write downloaded APKs to shared storage so the PICO ToBService can read them for silent install, and read/write shared-storage directories for file/folder push (sync) |
+| `MANAGE_EXTERNAL_STORAGE` | Write downloaded APKs to shared storage so the PICO ToBService can read them for silent install; read/write shared-storage directories for file/folder push (sync); and read shared storage for directory integrity checks (`VERIFY_DIR`) |
+| `QUERY_ALL_PACKAGES` | Resolve an arbitrary installed package via `PackageManager` for APK integrity checks (`VERIFY_APK`). On API 30+ package visibility is filtered; an operator may verify any package, so a `<queries>` allowlist cannot cover it. This client is privately distributed (not on Google Play), so the Play-policy restriction on this permission does not apply. |
 
 Battery percentage and charging state are read with Android's standard battery
 status APIs (`ACTION_BATTERY_CHANGED` / `BatteryManager`), which do not require

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -412,24 +412,66 @@ records `{relative_path, size, sha256}` (paths forward-slashed, relative to the 
 directory), sorts entries by the **UTF-8 byte order** of `relative_path`, and hashes
 `relative_path + "\n" + size + "\n" + sha256 + "\n"` per entry into a single `tree_hash`.
 The console compares `tree_hash` for same/different and, when both manifests are present,
-diffs them to list missing / added / changed files. Policy (identical across all
-implementations): symlinks are not followed and are excluded, empty directories are not
-represented, and an unreadable file makes the whole result an error. Directory checks are
+diffs them to list missing / added / changed files. Policy: empty directories are not
+represented, and an unreadable file makes the whole result an error. The device and the
+`styly-mdm hash` CLI also exclude symlinks without following them; the browser cannot —
+neither `webkitdirectory` nor the Entries API exposes whether an entry is a link — so a
+reference folder containing symlinks will hash their contents and mismatch a device that
+skipped them. Directory checks are
 bounded to **shared external storage** (`/sdcard`), which is what `MANAGE_EXTERNAL_STORAGE`
 grants; the device canonicalizes the path and refuses anything outside that root. Large
 trees can omit the per-file `manifest` (a cap on entry count) and still compare by
-`tree_hash`. Note that OS-generated hidden files in a reference folder (e.g. macOS
-`.DS_Store`, `Thumbs.db`) are hashed as content and will show up as spurious "added"
-entries against a device that does not have them — prune them from the reference first.
+`tree_hash`.
 
-**Generating a reference.** In the console, pick a local `.apk` (Verify APK) or a folder
-(Verify Directory) — it is hashed in the browser, never uploaded. For large trees the
-`styly-mdm hash <path>` CLI is faster and deterministic; it prints the same JSON the
-console consumes and runs on the machine that holds the tree (which may differ from the
-server host):
+**OS metadata is not content.** `integrity.is_os_metadata()` — mirrored as `isOsMetadata()`
+in the console — matches `.DS_Store`, `Thumbs.db`, `desktop.ini`, AppleDouble `._*` sidecars,
+`__MACOSX/`, `.Spotlight-V100/` and friends on *any* path segment, case-insensitively. It is
+applied in exactly two places, and they are the same place conceptually: `POST /api/bundles`
+drops these files on the way into a push bundle, so a device never receives them; and the
+**reference builders** (browser and `styly-mdm hash`) drop them too, so a reference describes
+what push actually delivers. Without the second half a macOS reference folder reports a
+permanent `missing N` — reference-only files land in **`missing`**, not `added` — against a
+device that is byte-identical. The list is deliberately narrow: `.git/`, Unity `.meta` and
+dotfiles at large are content, and silently dropping content is worse than keeping a stray
+`.DS_Store`. The count is reported (`excluded_count`, shown in the console) rather than hidden.
+
+The **device does not apply this filter** — it reports what is actually on disk, and needs no
+client release to stay correct. So the invariant is not "all three implementations hash any
+input identically"; it is: *the reference builders agree with each other and model what push
+delivers, while the device reports ground truth.*
+
+Content can reach a device by routes other than push — copied over USB/MTP from a Mac, say —
+and then the device really does hold `.DS_Store` files. `classifyDir()` therefore re-folds the
+device's manifest with the OS-metadata entries removed before it declares a mismatch, and
+reports `N OS metadata ignored on device`. The device sends its manifest already sorted by
+UTF-8 byte order, and removing entries preserves that order, so the re-fold is exact. Genuine
+differences still surface: a missing or changed content file is reported as before. Above the
+device's manifest entry cap no manifest is sent, so OS metadata cannot be discounted — the
+console says `too large for a per-file diff` rather than blaming the operator's tree.
+
+**Generating a reference.** In the console, pick a local `.apk` (Verify APK) or supply a
+folder (Verify Directory) — it is hashed in the browser, never uploaded.
+
+A reference folder can be **dropped onto the Verify Directory drop zone** or chosen with
+*Choose Folder*. Both produce the same manifest, but the drop zone exists because Chrome
+shows a *"Upload N files to this site?"* confirmation for any `<input webkitdirectory>`
+pick — alarming, and untrue here. A drop instead arrives via `DataTransferItem.webkitGetAsEntry()`,
+which raises no such prompt and, unlike `showDirectoryPicker()`, works on the non-secure
+`http://<LAN-IP>` origin the console is served from. Two traps make the drop path subtly
+wrong if reimplemented: `DirectoryReader.readEntries()` returns the directory in batches
+(100 at a time in Chrome) and must be pumped until it yields an empty array, or the
+manifest is silently truncated into a false mismatch; and `webkitGetAsEntry()` must be
+called before the handler's first `await`, because `DataTransferItem`s are emptied as soon
+as it yields. Because the Entries API cannot identify symlinks, the walk is bounded by a
+depth cap instead of the device's symlink skip.
+
+For large trees the `styly-mdm hash <path>` CLI is faster and deterministic — the console's
+pure-JS SHA-256 runs around 80 MB/s, since `crypto.subtle` is unavailable on a non-secure
+origin. It prints the same JSON the console consumes and runs on the machine that holds the
+tree (which may differ from the server host):
 
 ```bash
-styly-mdm hash ./content            # directory -> {tree_hash, file_count, total_size, manifest}
+styly-mdm hash ./content            # directory -> {tree_hash, file_count, total_size, excluded_count, manifest}
 styly-mdm hash ./app-release.apk    # APK       -> {size, cd_sha256}
 ```
 

--- a/mdm-client/app/src/main/AndroidManifest.xml
+++ b/mdm-client/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
+    <!-- Required so integrity verification (VERIFY_APK) can resolve an arbitrary installed
+         package via PackageManager. On API 30+ package visibility is filtered; an operator
+         may verify any package name, so a <queries> allowlist cannot cover it. This app is
+         a privately distributed enterprise MDM client (not on Google Play), so the Play
+         policy restriction on this permission does not apply. -->
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
     <application
         android:name=".MdmClientApplication"

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -6,6 +6,8 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
 import android.os.IBinder
@@ -14,11 +16,19 @@ import com.pvr.tobservice.ToBServiceHelper
 import com.pvr.tobservice.enums.PBS_PackageControlEnum
 import com.pvr.tobservice.interfaces.IIntCallback
 import com.pvr.tobservice.interfaces.IToBServiceProxy
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.io.FileOutputStream
+import java.io.RandomAccessFile
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.security.MessageDigest
 import java.util.zip.ZipFile
 
 /**
@@ -44,6 +54,20 @@ class MdmClientService : Service() {
             "android", "download", "downloads", "dcim", "pictures", "movies", "music",
             "documents", "alarms", "notifications", "podcasts", "ringtones"
         )
+
+        // Integrity verification (issue #37). The ZIP End-Of-Central-Directory record is
+        // the fixed 22-byte trailer plus an optional comment of up to 0xFFFF bytes.
+        private const val EOCD_MIN = 22
+        private const val MAX_EOCD_COMMENT = 0xFFFF
+        // A CD offset of 0xFFFFFFFF signals ZIP64, which we do not parse (standard APKs
+        // are not ZIP64); we return a clear error instead of hashing a wrong range.
+        private const val ZIP64_SENTINEL = 0xFFFFFFFFL
+        // Bound directory verification so a huge/hostile tree cannot exhaust the device.
+        private const val MAX_VERIFY_DIR_ENTRIES = 50_000
+        // Above this many files the per-file manifest is omitted (tree_hash still returned).
+        private const val MAX_VERIFY_DIR_MANIFEST_ENTRIES = 2_000
+
+        private val HEX = "0123456789abcdef".toCharArray()
     }
 
     private lateinit var webSocketManager: WebSocketManager
@@ -84,6 +108,8 @@ class MdmClientService : Service() {
             "EXECUTE_LAUNCH" -> executeLaunch(payload)
             "EXECUTE_INSTALL" -> executeInstall(payload)
             "EXECUTE_PUSH_FILES" -> executePushFiles(payload)
+            "EXECUTE_VERIFY_APK" -> executeVerifyApk(payload)
+            "EXECUTE_VERIFY_DIR" -> executeVerifyDir(payload)
             "SET_STARTUP_APP" -> handleSetStartupApp(payload)
             "CLEAR_STARTUP_APP" -> handleClearStartupApp()
             else -> Log.w(TAG, "Unknown command type: $type")
@@ -638,6 +664,297 @@ class MdmClientService : Service() {
             108 -> "Incompatible APK"
             else -> "Unknown install error"
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integrity verification (issue #37). Computes the same size + ZIP
+    // Central-Directory digest / directory tree hash that the console (pure JS)
+    // and the `styly-mdm hash` CLI (Python) compute, so the browser can compare
+    // a device against a local reference without any upload. Hashing runs on a
+    // worker thread (a base.apk can be 1 GB+); the reply goes back over the same
+    // WebSocket send helper the install flow uses.
+    // -----------------------------------------------------------------------
+
+    private fun executeVerifyApk(payload: JSONObject) {
+        val pkg = payload.optString("package_name", "")
+        if (pkg.isEmpty()) {
+            Log.e(TAG, "EXECUTE_VERIFY_APK missing package_name")
+            sendVerifyApkResult(pkg, found = false, error = "Missing package_name")
+            return
+        }
+        Thread {
+            try {
+                val pm = packageManager
+                val appInfo = pm.getApplicationInfo(pkg, 0)
+                val apkFile = File(appInfo.sourceDir)
+                val size = apkFile.length()
+                val cdSha256 = apkCentralDirectoryDigest(apkFile)
+                val fullSha256 = fileSha256(apkFile)
+                @Suppress("DEPRECATION")
+                val pkgInfo = pm.getPackageInfo(pkg, PackageManager.GET_SIGNING_CERTIFICATES)
+                sendVerifyApkResult(
+                    pkg,
+                    found = true,
+                    size = size,
+                    cdSha256 = cdSha256,
+                    fullSha256 = fullSha256,
+                    versionCode = pkgInfo.longVersionCode,
+                    versionName = pkgInfo.versionName ?: "",
+                    signerSha256 = signerSha256(pkgInfo)
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                Log.i(TAG, "VERIFY_APK: package not installed: $pkg")
+                sendVerifyApkResult(pkg, found = false)
+            } catch (e: Exception) {
+                Log.e(TAG, "VERIFY_APK failed for $pkg", e)
+                sendVerifyApkResult(pkg, found = false, error = e.message ?: "Unknown error")
+            }
+        }.start()
+    }
+
+    private fun executeVerifyDir(payload: JSONObject) {
+        val path = payload.optString("path", "")
+        Thread {
+            try {
+                if (!hasExternalStorageAccess()) {
+                    sendVerifyDirResult(
+                        path, found = false,
+                        error = "All files access (MANAGE_EXTERNAL_STORAGE) is not granted on this device"
+                    )
+                    return@Thread
+                }
+                val root = resolveVerifyDir(path)
+                if (!root.exists()) {
+                    sendVerifyDirResult(path, found = false)
+                    return@Thread
+                }
+                if (!root.isDirectory) {
+                    sendVerifyDirResult(path, found = false, error = "Path is not a directory")
+                    return@Thread
+                }
+                sendVerifyDirResult(path, found = true, result = dirManifest(root))
+            } catch (e: SecurityException) {
+                Log.e(TAG, "VERIFY_DIR denied for $path", e)
+                sendVerifyDirResult(path, found = false, error = e.message ?: "Path not permitted")
+            } catch (e: Exception) {
+                Log.e(TAG, "VERIFY_DIR failed for $path", e)
+                sendVerifyDirResult(path, found = false, error = e.message ?: "Unknown error")
+            }
+        }.start()
+    }
+
+    /**
+     * Canonicalize a device directory path and enforce that it stays within shared
+     * external storage. Verification only reads, but bounding to shared storage keeps it
+     * to the scope operators distribute content into and matches what MANAGE_EXTERNAL_STORAGE
+     * actually grants. Throws for an invalid or out-of-scope path.
+     */
+    private fun resolveVerifyDir(path: String): File {
+        if (path.isEmpty() || !path.startsWith("/")) {
+            throw IllegalArgumentException("A valid absolute path is required")
+        }
+        val storageRoot = Environment.getExternalStorageDirectory()
+            ?: throw IllegalStateException("Shared external storage is unavailable")
+        val root = storageRoot.canonicalFile
+        val target = File(path).canonicalFile
+        if (target != root && !target.path.startsWith(root.path + File.separator)) {
+            throw SecurityException("Path is outside shared storage (${root.path})")
+        }
+        return target
+    }
+
+    /**
+     * SHA-256 of the ZIP Central-Directory region [CD_offset .. EOF]. Parses the EOCD to
+     * find CD_offset (little-endian uint32) — this covers every entry's CRC-32 + sizes plus
+     * the EOCD, while reading only a few hundred KB regardless of APK size.
+     */
+    private fun apkCentralDirectoryDigest(file: File): String {
+        RandomAccessFile(file, "r").use { raf ->
+            val fileLen = raf.length()
+            val readLen = minOf(fileLen, (EOCD_MIN + MAX_EOCD_COMMENT).toLong()).toInt()
+            val tailStart = fileLen - readLen
+            val tail = ByteArray(readLen)
+            raf.seek(tailStart)
+            raf.readFully(tail)
+            val eocdOff = findEocd(tail, fileLen, tailStart)
+            if (eocdOff < 0) throw IllegalStateException("End Of Central Directory record not found")
+            // ByteBuffer defaults to big-endian — ZIP fields are little-endian.
+            val bb = ByteBuffer.wrap(tail).order(ByteOrder.LITTLE_ENDIAN)
+            val cdOffset = bb.getInt(eocdOff + 16).toLong() and 0xFFFFFFFFL
+            if (cdOffset == ZIP64_SENTINEL) throw IllegalStateException("zip64 not supported")
+            val md = MessageDigest.getInstance("SHA-256")
+            raf.seek(cdOffset)
+            val buf = ByteArray(1 shl 20)
+            var remaining = fileLen - cdOffset
+            while (remaining > 0) {
+                val n = raf.read(buf, 0, minOf(buf.size.toLong(), remaining).toInt())
+                if (n <= 0) break
+                md.update(buf, 0, n)
+                remaining -= n
+            }
+            return md.digest().toHex()
+        }
+    }
+
+    private fun findEocd(tail: ByteArray, fileLen: Long, tailStart: Long): Int {
+        val bb = ByteBuffer.wrap(tail).order(ByteOrder.LITTLE_ENDIAN)
+        for (i in tail.size - EOCD_MIN downTo 0) {
+            if ((tail[i].toInt() and 0xff) == 0x50 && (tail[i + 1].toInt() and 0xff) == 0x4b &&
+                (tail[i + 2].toInt() and 0xff) == 0x05 && (tail[i + 3].toInt() and 0xff) == 0x06
+            ) {
+                val commentLen = bb.getShort(i + 20).toInt() and 0xffff
+                if (tailStart + i + EOCD_MIN + commentLen == fileLen) return i
+            }
+        }
+        return -1
+    }
+
+    private fun fileSha256(file: File): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buf = ByteArray(1 shl 20)
+            while (true) {
+                val n = input.read(buf)
+                if (n <= 0) break
+                md.update(buf, 0, n)
+            }
+        }
+        return md.digest().toHex()
+    }
+
+    private fun signerSha256(pkgInfo: PackageInfo): String {
+        val signers = pkgInfo.signingInfo?.apkContentsSigners ?: return ""
+        if (signers.isEmpty()) return ""
+        return MessageDigest.getInstance("SHA-256").digest(signers[0].toByteArray()).toHex()
+    }
+
+    private class DirResult(
+        val treeHash: String,
+        val fileCount: Int,
+        val totalSize: Long,
+        val manifest: JSONArray?
+    )
+
+    private class DirEntry(val relativePath: String, val size: Long, val sha256: String)
+
+    /**
+     * Walk a directory into a manifest and tree hash. Policy (matches the console and CLI):
+     * symlinks are not followed and excluded; empty directories are not represented; entries
+     * are sorted by the UTF-8 byte order of their relative path.
+     */
+    private fun dirManifest(root: File): DirResult {
+        val entries = ArrayList<DirEntry>()
+        walkDir(root, "", entries)
+        entries.sortWith(Comparator { a, b -> utf8Compare(a.relativePath, b.relativePath) })
+
+        val md = MessageDigest.getInstance("SHA-256")
+        var totalSize = 0L
+        for (e in entries) {
+            totalSize += e.size
+            md.update("${e.relativePath}\n${e.size}\n${e.sha256}\n".toByteArray(Charsets.UTF_8))
+        }
+        val manifest = if (entries.size <= MAX_VERIFY_DIR_MANIFEST_ENTRIES) {
+            JSONArray().apply {
+                for (e in entries) {
+                    put(JSONObject().apply {
+                        put("relative_path", e.relativePath)
+                        put("size", e.size)
+                        put("sha256", e.sha256)
+                    })
+                }
+            }
+        } else null
+        return DirResult(md.digest().toHex(), entries.size, totalSize, manifest)
+    }
+
+    private fun walkDir(dir: File, relBase: String, out: ArrayList<DirEntry>) {
+        Files.newDirectoryStream(dir.toPath()).use { stream ->
+            for (child in stream) {
+                if (Files.isSymbolicLink(child)) continue
+                val name = child.fileName.toString()
+                val rel = if (relBase.isEmpty()) name else "$relBase/$name"
+                val attr = Files.readAttributes(
+                    child, BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS
+                )
+                when {
+                    attr.isDirectory -> walkDir(child.toFile(), rel, out)
+                    attr.isRegularFile -> {
+                        if (out.size >= MAX_VERIFY_DIR_ENTRIES) {
+                            throw IllegalStateException("Directory has more than $MAX_VERIFY_DIR_ENTRIES files")
+                        }
+                        out.add(DirEntry(rel, attr.size(), fileSha256(child.toFile())))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun utf8Compare(a: String, b: String): Int {
+        val ea = a.toByteArray(Charsets.UTF_8)
+        val eb = b.toByteArray(Charsets.UTF_8)
+        val n = minOf(ea.size, eb.size)
+        for (i in 0 until n) {
+            val d = (ea[i].toInt() and 0xff) - (eb[i].toInt() and 0xff)
+            if (d != 0) return d
+        }
+        return ea.size - eb.size
+    }
+
+    private fun ByteArray.toHex(): String {
+        val sb = StringBuilder(size * 2)
+        for (b in this) {
+            val v = b.toInt() and 0xff
+            sb.append(HEX[v ushr 4])
+            sb.append(HEX[v and 0x0f])
+        }
+        return sb.toString()
+    }
+
+    private fun sendVerifyApkResult(
+        packageName: String,
+        found: Boolean,
+        size: Long? = null,
+        cdSha256: String? = null,
+        fullSha256: String? = null,
+        versionCode: Long? = null,
+        versionName: String? = null,
+        signerSha256: String? = null,
+        error: String? = null
+    ) {
+        val result = JSONObject().apply {
+            put("type", "VERIFY_APK_RESULT")
+            put("package_name", packageName)
+            put("found", found)
+            if (size != null) put("size", size)
+            if (cdSha256 != null) put("cd_sha256", cdSha256)
+            if (fullSha256 != null) put("full_sha256", fullSha256)
+            if (versionCode != null) put("version_code", versionCode)
+            if (versionName != null) put("version_name", versionName)
+            if (!signerSha256.isNullOrEmpty()) put("signer_sha256", signerSha256)
+            if (!error.isNullOrEmpty()) put("error", error)
+        }
+        webSocketManager.sendMessage(result)
+    }
+
+    private fun sendVerifyDirResult(
+        path: String,
+        found: Boolean,
+        result: DirResult? = null,
+        error: String? = null
+    ) {
+        val msg = JSONObject().apply {
+            put("type", "VERIFY_DIR_RESULT")
+            put("path", path)
+            put("found", found)
+            if (result != null) {
+                put("tree_hash", result.treeHash)
+                put("file_count", result.fileCount)
+                put("total_size", result.totalSize)
+                if (result.manifest != null) put("manifest", result.manifest)
+            }
+            if (!error.isNullOrEmpty()) put("error", error)
+        }
+        webSocketManager.sendMessage(msg)
     }
 
     private fun handleStatusChanged(connected: Boolean, message: String) {

--- a/mdm-server/styly_mdm/integrity.py
+++ b/mdm-server/styly_mdm/integrity.py
@@ -1,0 +1,150 @@
+"""Content-integrity helpers: APK Central-Directory digest and directory tree hashing.
+
+Used by the ``styly-mdm hash`` CLI subcommand to compute a *local reference* for the
+console's on-demand integrity check (issue #37). The control server itself never hashes
+anything for verification — it only relays the ``VERIFY_*`` messages. These helpers are
+kept dependency-free and pure so they can be unit-tested and, crucially, cross-checked
+byte-for-byte against the browser (pure JS) and device (Kotlin) implementations of the
+exact same algorithms. If any implementation disagrees on a single byte of the hashed
+range, every device would report a mismatch, so the algorithm here is the canonical spec.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+
+# End Of Central Directory record signature ("PK\x05\x06").
+EOCD_SIGNATURE = b"\x50\x4b\x05\x06"
+# The ZIP comment length field is a uint16, so the EOCD starts at most this many bytes
+# (plus the 22-byte fixed record) from EOF.
+MAX_EOCD_COMMENT = 0xFFFF
+EOCD_MIN_SIZE = 22
+# A CD offset of 0xFFFFFFFF in the classic EOCD means the real value lives in a ZIP64
+# record. We do not parse ZIP64 (standard APKs are not ZIP64); we surface a clear error
+# rather than hash a wrong byte range.
+ZIP64_SENTINEL = 0xFFFFFFFF
+
+_CHUNK = 1024 * 1024
+
+
+class Zip64UnsupportedError(ValueError):
+    """Raised when an archive uses ZIP64 (CD offset sentinel), which we do not hash."""
+
+
+def _find_eocd(tail: bytes, file_len: int, tail_start: int) -> int:
+    """Return the absolute offset of the EOCD record within the file.
+
+    ``tail`` is the final ``len(tail)`` bytes of the file, beginning at absolute offset
+    ``tail_start``. We scan backwards and accept the *last* EOCD signature whose declared
+    comment length makes the record end exactly at EOF — the length check stops a stray
+    "PK\\x05\\x06" byte sequence inside the archive or comment from being mistaken for the
+    real record. Raises ``ValueError`` if no valid EOCD is found.
+    """
+    for i in range(len(tail) - EOCD_MIN_SIZE, -1, -1):
+        if tail[i:i + 4] != EOCD_SIGNATURE:
+            continue
+        comment_len = struct.unpack_from("<H", tail, i + 20)[0]
+        eocd_abs = tail_start + i
+        if eocd_abs + EOCD_MIN_SIZE + comment_len == file_len:
+            return eocd_abs
+    raise ValueError("End Of Central Directory record not found")
+
+
+def apk_cd_digest(path: str) -> tuple[int, str]:
+    """Return ``(size, cd_sha256_hex)`` for an APK/ZIP file.
+
+    ``cd_sha256`` is the SHA-256 of ``file[CD_offset .. EOF]``, where ``CD_offset`` is
+    read (little-endian uint32) from the parsed EOCD record. This region covers the
+    Central Directory — every entry's CRC-32 and compressed/uncompressed sizes — plus the
+    EOCD itself, so any real change to the archive perturbs it, while reading only a few
+    hundred KB regardless of the APK size.
+    """
+    file_len = os.path.getsize(path)
+    with open(path, "rb") as f:
+        read_len = min(file_len, EOCD_MIN_SIZE + MAX_EOCD_COMMENT)
+        tail_start = file_len - read_len
+        f.seek(tail_start)
+        tail = f.read(read_len)
+        eocd_off = _find_eocd(tail, file_len, tail_start) - tail_start
+        cd_offset = struct.unpack_from("<I", tail, eocd_off + 16)[0]
+        if cd_offset == ZIP64_SENTINEL:
+            raise Zip64UnsupportedError("zip64 not supported")
+        f.seek(cd_offset)
+        h = hashlib.sha256()
+        while True:
+            chunk = f.read(_CHUNK)
+            if not chunk:
+                break
+            h.update(chunk)
+    return file_len, h.hexdigest()
+
+
+def _file_sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(_CHUNK)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _iter_files(root: str):
+    """Yield ``(relative_path, absolute_path)`` for every regular file under ``root``.
+
+    Policy (must match the JS and Kotlin implementations): symlinks are not followed and
+    are excluded; directories (including empty ones) are not represented; ``relative_path``
+    uses forward slashes with no leading slash.
+    """
+    root = os.path.abspath(root)
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        # os.walk(followlinks=False) already will not descend into symlinked dirs, but
+        # prune them explicitly so they are never even listed.
+        dirnames[:] = [d for d in dirnames
+                       if not os.path.islink(os.path.join(dirpath, d))]
+        for name in filenames:
+            abspath = os.path.join(dirpath, name)
+            if os.path.islink(abspath):
+                continue
+            rel = os.path.relpath(abspath, root).replace(os.sep, "/")
+            yield rel, abspath
+
+
+def dir_manifest(path: str, manifest_entry_cap: int | None = None) -> dict:
+    """Return ``{tree_hash, file_count, total_size, manifest?}`` for a directory tree.
+
+    ``manifest`` is a list of ``{relative_path, size, sha256}`` sorted by the UTF-8 byte
+    order of ``relative_path``. ``tree_hash`` is the SHA-256 over, for each entry in that
+    order, the UTF-8 bytes of ``f"{relative_path}\\n{size}\\n{sha256}\\n"``. When
+    ``manifest_entry_cap`` is given and there are more files than the cap, the ``manifest``
+    key is omitted (``tree_hash`` alone still distinguishes same/different).
+    """
+    entries = []
+    for rel, abspath in _iter_files(path):
+        entries.append({
+            "relative_path": rel,
+            "size": os.path.getsize(abspath),
+            "sha256": _file_sha256(abspath),
+        })
+    # Sort by the UTF-8 byte sequence, not Python's default str ordering, so JS
+    # (UTF-16 code units) and Kotlin can reproduce the exact same order for non-ASCII.
+    entries.sort(key=lambda e: e["relative_path"].encode("utf-8"))
+
+    h = hashlib.sha256()
+    total_size = 0
+    for e in entries:
+        total_size += e["size"]
+        line = "{}\n{}\n{}\n".format(e["relative_path"], e["size"], e["sha256"])
+        h.update(line.encode("utf-8"))
+
+    result = {
+        "tree_hash": h.hexdigest(),
+        "file_count": len(entries),
+        "total_size": total_size,
+    }
+    if manifest_entry_cap is None or len(entries) <= manifest_entry_cap:
+        result["manifest"] = entries
+    return result

--- a/mdm-server/styly_mdm/integrity.py
+++ b/mdm-server/styly_mdm/integrity.py
@@ -92,12 +92,69 @@ def _file_sha256(path: str) -> str:
     return h.hexdigest()
 
 
-def _iter_files(root: str):
-    """Yield ``(relative_path, absolute_path)`` for every regular file under ``root``.
+# OS-generated metadata that rides along with a folder pick. None of it is content the user
+# meant to ship, and a folder copied via USB can carry one `._*` sidecar per file, so these
+# are dropped when a bundle is built and, for the same reason, when an integrity reference is
+# computed: the reference must describe what `push files` actually delivers to a device.
+#
+# Deliberately limited to files the OS creates on its own. Anything a user could plausibly
+# have authored — `.git/`, Unity `.meta`, dotfiles at large — is kept as-is: a silent drop
+# of real content would be far worse than an unwanted `.DS_Store`.
+_EXCLUDED_NAMES = frozenset({
+    ".ds_store",              # macOS Finder, one per directory
+    "thumbs.db",              # Windows Explorer thumbnail cache
+    "ehthumbs.db",
+    "desktop.ini",            # Windows folder settings
+    ".directory",             # KDE folder settings
+    ".apdisk",                # macOS
+    ".volumeicon.icns",       # macOS
+})
 
-    Policy (must match the JS and Kotlin implementations): symlinks are not followed and
-    are excluded; directories (including empty ones) are not represented; ``relative_path``
-    uses forward slashes with no leading slash.
+# Directories the OS owns end-to-end; excluding the directory excludes everything under it.
+_EXCLUDED_DIRS = frozenset({
+    ".spotlight-v100",
+    ".trashes",
+    ".fseventsd",
+    ".temporaryitems",
+    ".documentrevisions-v100",
+    "__macosx",               # created when a macOS-made zip is expanded
+    "$recycle.bin",
+})
+
+
+def is_os_metadata(relpath: str) -> bool:
+    """Return True if any path segment of ``relpath`` is OS-generated metadata.
+
+    Matching is case-insensitive: the same file is ``Thumbs.db`` on one machine and
+    ``thumbs.db`` on another, and macOS/Windows filesystems do not distinguish them.
+    Matching on *any* segment means a file nested under an excluded directory is dropped
+    along with it.
+
+    The console mirrors this predicate in JavaScript; the two must agree exactly, or a
+    browser-built reference and a CLI-built reference would hash the same tree differently.
+    """
+    for seg in relpath.split("/"):
+        low = seg.lower()
+        if low in _EXCLUDED_NAMES or low in _EXCLUDED_DIRS:
+            return True
+        # AppleDouble resource forks: one `._name` sidecar per file, created whenever a
+        # macOS folder is copied onto a non-HFS filesystem such as a USB stick.
+        if low.startswith("._"):
+            return True
+        # Per-user trash directories on Linux removable media (`.Trash-1000`).
+        if low.startswith(".trash-"):
+            return True
+    return False
+
+
+def _iter_files(root: str, excluded: list[str] | None = None):
+    """Yield ``(relative_path, absolute_path)`` for every regular content file under ``root``.
+
+    Policy: symlinks are not followed and are excluded; directories (including empty ones)
+    are not represented; OS metadata (:func:`is_os_metadata`) is excluded and, when
+    ``excluded`` is given, appended to it; ``relative_path`` uses forward slashes with no
+    leading slash. The browser's reference builder applies the same policy, except that it
+    cannot recognize symlinks.
     """
     root = os.path.abspath(root)
     for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
@@ -110,6 +167,13 @@ def _iter_files(root: str):
             if os.path.islink(abspath):
                 continue
             rel = os.path.relpath(abspath, root).replace(os.sep, "/")
+            # Matched per file rather than by pruning dirnames, so every dropped file is
+            # counted individually — the operator sees how much was left out, as the
+            # bundle upload already reports.
+            if is_os_metadata(rel):
+                if excluded is not None:
+                    excluded.append(rel)
+                continue
             yield rel, abspath
 
 
@@ -121,9 +185,13 @@ def dir_manifest(path: str, manifest_entry_cap: int | None = None) -> dict:
     order, the UTF-8 bytes of ``f"{relative_path}\\n{size}\\n{sha256}\\n"``. When
     ``manifest_entry_cap`` is given and there are more files than the cap, the ``manifest``
     key is omitted (``tree_hash`` alone still distinguishes same/different).
+
+    ``excluded_count`` reports how many OS-metadata files were left out, so a caller can say
+    so rather than silently hashing a different set of files than the operator picked.
     """
     entries = []
-    for rel, abspath in _iter_files(path):
+    excluded: list[str] = []
+    for rel, abspath in _iter_files(path, excluded):
         entries.append({
             "relative_path": rel,
             "size": os.path.getsize(abspath),
@@ -144,6 +212,7 @@ def dir_manifest(path: str, manifest_entry_cap: int | None = None) -> dict:
         "tree_hash": h.hexdigest(),
         "file_count": len(entries),
         "total_size": total_size,
+        "excluded_count": len(excluded),
     }
     if manifest_entry_cap is None or len(entries) <= manifest_entry_cap:
         result["manifest"] = entries

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import socket
+import sys
 import tempfile
 import time
 import zipfile
@@ -668,7 +669,13 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     else:
                         log.warning("DOWNLOAD_COMPLETE before REGISTER")
 
-                elif msg_type in {"LAUNCH_RESULT", "INSTALL_RESULT", "PUSH_FILES_RESULT"}:
+                elif msg_type in {
+                    "LAUNCH_RESULT",
+                    "INSTALL_RESULT",
+                    "PUSH_FILES_RESULT",
+                    "VERIFY_APK_RESULT",
+                    "VERIFY_DIR_RESULT",
+                }:
                     if device_id:
                         data.setdefault("device_id", device_id)
                     # Fallback transfer-slot release: an older client that never
@@ -745,6 +752,12 @@ async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
 
                 elif msg_type == "PUSH_FILES":
                     await handle_push_files(ws, data)
+
+                elif msg_type == "VERIFY_APK":
+                    await handle_verify_apk(ws, data)
+
+                elif msg_type == "VERIFY_DIR":
+                    await handle_verify_dir(ws, data)
 
                 elif msg_type == "SET_STARTUP_APP":
                     await handle_set_startup_app(ws, data)
@@ -1366,6 +1379,128 @@ async def handle_push_files(admin_ws: web.WebSocketResponse, data: dict):
 
 
 # ---------------------------------------------------------------------------
+# Integrity verification (issue #37) — relay only; no hashing on the server.
+# The reference is computed client-side in the browser (or via `styly-mdm hash`)
+# and the match/mismatch comparison happens in the browser. The server just fans
+# EXECUTE_VERIFY_* out to devices, exactly like INSTALL_APK, and forwards each
+# device's VERIFY_*_RESULT back to the admins (see the device forward set above).
+# ---------------------------------------------------------------------------
+
+async def _fanout_execute(
+    admin_ws: web.WebSocketResponse,
+    target_devices: list[str],
+    execute_msg: str,
+    verb: str,
+) -> tuple[int, int] | None:
+    """Send an already-serialized EXECUTE_* message to the resolved online targets.
+
+    Returns (sent_count, target_count), or None (after sending an ERROR to the admin)
+    when no online target matched.
+    """
+    target_ids = resolve_target_ids(target_devices)
+    if not target_ids:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "No matching online devices found",
+        }))
+        return None
+
+    sent_count = 0
+    for did in target_ids:
+        entry = devices.get(did)
+        if entry:
+            try:
+                await entry["ws"].send_str(execute_msg)
+                sent_count += 1
+            except ConnectionResetError:
+                log.warning("Failed to send %s to %s (disconnected)", verb, did)
+
+    return sent_count, len(target_ids)
+
+
+async def handle_verify_apk(admin_ws: web.WebSocketResponse, data: dict):
+    """Forward a VERIFY_APK command to target HMDs (mirrors handle_install_apk).
+
+    VERIFY_APK carries only {target_devices, package_name}; the local reference
+    (size + Central-Directory digest) never leaves the browser.
+    """
+    package_name: str = data.get("package_name", "")
+    if not package_name:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "package_name is required",
+        }))
+        return
+
+    execute_msg = json.dumps({
+        "type": "EXECUTE_VERIFY_APK",
+        "package_name": package_name,
+    })
+    result = await _fanout_execute(
+        admin_ws, data.get("target_devices", []), execute_msg, "EXECUTE_VERIFY_APK"
+    )
+    if result is None:
+        return
+    sent_count, target_count = result
+    log.info("VERIFY_APK: sent %s to %d/%d devices", package_name, sent_count, target_count)
+
+    await admin_ws.send_str(json.dumps({
+        "type": "VERIFY_SENT",
+        "package_name": package_name,
+        "sent_count": sent_count,
+        "target_count": target_count,
+    }))
+
+
+def is_syntactically_safe_verify_path(path: str) -> bool:
+    """Light syntactic guard for a device directory path (VERIFY_DIR).
+
+    Verification only reads, so this is advisory; the device performs the
+    authoritative canonical check that the path stays within shared external
+    storage. Here we just reject the obviously-wrong: empty, relative, or
+    containing a `..` traversal component.
+    """
+    if not path or not path.startswith("/"):
+        return False
+    parts = [p for p in path.split("/") if p]
+    return ".." not in parts
+
+
+async def handle_verify_dir(admin_ws: web.WebSocketResponse, data: dict):
+    """Forward a VERIFY_DIR command to target HMDs.
+
+    VERIFY_DIR carries only {target_devices, path}; the local reference
+    (manifest + tree hash) never leaves the browser.
+    """
+    path: str = data.get("path", "")
+    if not is_syntactically_safe_verify_path(path):
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "A valid absolute path without '..' is required",
+        }))
+        return
+
+    execute_msg = json.dumps({
+        "type": "EXECUTE_VERIFY_DIR",
+        "path": path,
+    })
+    result = await _fanout_execute(
+        admin_ws, data.get("target_devices", []), execute_msg, "EXECUTE_VERIFY_DIR"
+    )
+    if result is None:
+        return
+    sent_count, target_count = result
+    log.info("VERIFY_DIR: sent %s to %d/%d devices", path, sent_count, target_count)
+
+    await admin_ws.send_str(json.dumps({
+        "type": "VERIFY_DIR_SENT",
+        "path": path,
+        "sent_count": sent_count,
+        "target_count": target_count,
+    }))
+
+
+# ---------------------------------------------------------------------------
 # APK upload handler
 # ---------------------------------------------------------------------------
 
@@ -1877,6 +2012,37 @@ async def run_server(port: int | None = None):
         await runner.cleanup()
 
 
+def run_hash_cli(path: str, manifest_cap: int | None) -> int:
+    """`styly-mdm hash <path>`: print a local integrity reference as JSON.
+
+    A file is treated as an APK/ZIP (size + Central-Directory digest); a directory
+    is walked into a manifest + tree hash. This is the deterministic, large-tree
+    reference the console compares device results against (issue #37), and it runs
+    on the machine that holds the tree — which may differ from the server host.
+    The tree is never uploaded.
+    """
+    from . import integrity
+
+    if os.path.isdir(path):
+        result = integrity.dir_manifest(path, manifest_entry_cap=manifest_cap)
+    elif os.path.isfile(path):
+        try:
+            size, cd_sha256 = integrity.apk_cd_digest(path)
+        except integrity.Zip64UnsupportedError:
+            print("error: zip64 archives are not supported", file=sys.stderr)
+            return 1
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+        result = {"size": size, "cd_sha256": cd_sha256}
+    else:
+        print(f"error: no such file or directory: {path}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="styly-mdm",
@@ -1901,7 +2067,25 @@ def main():
         help="Max simultaneous APK transfers per install job "
         "(default: $MDM_MAX_CONCURRENT_TRANSFERS or 5).",
     )
+    subparsers = parser.add_subparsers(dest="command")
+    hash_parser = subparsers.add_parser(
+        "hash",
+        help="Compute a local integrity reference (APK CD-digest or directory "
+        "tree hash) and print it as JSON. Nothing is uploaded.",
+    )
+    hash_parser.add_argument("path", help="Path to an .apk file or a directory.")
+    hash_parser.add_argument(
+        "--manifest-cap",
+        type=int,
+        default=None,
+        help="For a directory, omit the per-file manifest when it has more than "
+        "this many entries (tree_hash is always printed).",
+    )
     args = parser.parse_args()
+
+    if args.command == "hash":
+        raise SystemExit(run_hash_cli(args.path, args.manifest_cap))
+
     if args.data_dir is not None:
         _apply_data_dir(args.data_dir)
     if args.max_concurrent_transfers is not None:

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from urllib.parse import unquote
 from aiohttp import web
 
+# Bundling and integrity references must agree on what counts as content, or a reference
+# built from a folder could never match the device that folder was pushed to.
+from .integrity import is_os_metadata
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -1595,7 +1599,7 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
 
             # Drop OS metadata before it is written to staging, so it never reaches the zip
             # and never counts against the entry limit. reader.next() drains the skipped part.
-            if is_excluded_bundle_entry(relpath):
+            if is_os_metadata(relpath):
                 skipped.append(relpath)
                 continue
 
@@ -1657,57 +1661,6 @@ async def upload_bundle_handler(request: web.Request) -> web.Response:
         "entry_count": len(relpaths),
         "skipped_count": len(skipped),
     })
-
-
-# OS-generated metadata that rides along with a folder pick. None of it is content the user
-# meant to upload, and a folder copied via USB can carry one `._*` sidecar per file, so these
-# are dropped when the bundle is built rather than shipped to every device.
-#
-# Deliberately limited to files the OS creates on its own. Anything a user could plausibly
-# have authored — `.git/`, Unity `.meta`, dotfiles at large — is uploaded as-is: a silent drop
-# of real content would be far worse than an unwanted `.DS_Store`.
-_EXCLUDED_NAMES = frozenset({
-    ".ds_store",              # macOS Finder, one per directory
-    "thumbs.db",              # Windows Explorer thumbnail cache
-    "ehthumbs.db",
-    "desktop.ini",            # Windows folder settings
-    ".directory",             # KDE folder settings
-    ".apdisk",                # macOS
-    ".volumeicon.icns",       # macOS
-})
-
-# Directories the OS owns end-to-end; excluding the directory excludes everything under it.
-_EXCLUDED_DIRS = frozenset({
-    ".spotlight-v100",
-    ".trashes",
-    ".fseventsd",
-    ".temporaryitems",
-    ".documentrevisions-v100",
-    "__macosx",               # created when a macOS-made zip is expanded
-    "$recycle.bin",
-})
-
-
-def is_excluded_bundle_entry(relpath: str) -> bool:
-    """Return True if any path segment of ``relpath`` is OS-generated metadata.
-
-    Matching is case-insensitive: the same file is ``Thumbs.db`` on one machine and
-    ``thumbs.db`` on another, and macOS/Windows filesystems do not distinguish them.
-    Matching on *any* segment means a file nested under an excluded directory is dropped
-    along with it.
-    """
-    for seg in relpath.split("/"):
-        low = seg.lower()
-        if low in _EXCLUDED_NAMES or low in _EXCLUDED_DIRS:
-            return True
-        # AppleDouble resource forks: one `._name` sidecar per file, created whenever a
-        # macOS folder is copied onto a non-HFS filesystem such as a USB stick.
-        if low.startswith("._"):
-            return True
-        # Per-user trash directories on Linux removable media (`.Trash-1000`).
-        if low.startswith(".trash-"):
-            return True
-    return False
 
 
 def _is_within(root: Path, target: Path) -> bool:

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -128,7 +128,7 @@
     .group-dev + .group-dev { border-top: 1px solid var(--border-soft); }
     .group-dev-name { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .group-dev-status { color: var(--text-secondary); font-size: 12px; white-space: nowrap; width: 66px; }
-    .group-dev-install { font-size: 12px; white-space: nowrap; text-align: right; min-width: 92px; }
+    .group-dev-task { font-size: 12px; white-space: nowrap; text-align: right; min-width: 92px; }
     .radio { width: 18px; height: 18px; border-radius: 50%; border: 1.5px solid #41475f; flex-shrink: 0; }
     .radio.on { border: 5px solid var(--accent); background: var(--bg-card); }
     .group-main { min-width: 0; flex: 1; }
@@ -167,7 +167,7 @@
     .battery.charging .battery-fill { background: var(--warning); }
     .battery-note { color: var(--text-muted); font-size: 11px; margin-left: 4px; }
     .battery-muted { color: var(--text-dim); }
-    .dev-install { font-size: 12px; padding-right: 14px; }
+    .dev-task { font-size: 12px; padding-right: 14px; }
     .ins-queued { color: var(--text-muted); }
     .ins-transferring { color: var(--info); }
     .ins-installing { color: var(--warning); }
@@ -179,12 +179,6 @@
     /* Verify (integrity check) — per-device results panel inside the Actions column */
     .verify-hint { color: var(--text-muted); font-size: 11px; margin-top: 8px; line-height: 1.4; }
     .verify-hint code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; color: var(--text-secondary); }
-    .verify-results { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
-    .verify-row { display: flex; align-items: baseline; gap: 8px; font-size: 12px; padding: 3px 0; border-top: 1px solid #232a3d; }
-    .verify-row:first-child { border-top: none; }
-    .verify-dev { font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto; }
-    .verify-stat { margin-left: auto; text-align: right; }
-    .verify-detail { color: var(--text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; }
 
     /* Select boxes */
     .selbox { width: 16px; height: 16px; border-radius: 4px; border: 1.5px solid #41475f; display: flex; align-items: center; justify-content: center; cursor: pointer; flex-shrink: 0; color: #fff; font-size: 11px; font-weight: 800; }
@@ -428,7 +422,6 @@
                 <input type="text" class="field" id="verifyApkPkg" placeholder="com.example.app (package name)">
                 <button class="btn btn-primary" id="btnVerifyApk" disabled>Verify on Selected</button>
                 <div class="verify-hint">Reference is hashed locally in your browser — nothing is uploaded.</div>
-                <div class="verify-results" id="verifyApkResults"></div>
               </div>
             </div>
             <div class="cmd-divider"></div>
@@ -446,7 +439,6 @@
                 </div>
                 <button class="btn btn-primary" id="btnVerifyDir" disabled>Verify on Selected</button>
                 <div class="verify-hint">Reference is hashed locally in your browser — nothing is uploaded. Dropping a folder skips the &ldquo;Upload N files&rdquo; prompt that Chrome always shows for <em>Choose Folder</em>. Large trees hash faster with <code>styly-mdm hash &lt;path&gt;</code> — load its JSON here. Shared storage only.</div>
-                <div class="verify-results" id="verifyDirResults"></div>
               </div>
             </div>
           </div>
@@ -492,7 +484,7 @@
       let userPickedTab = false;       // true once the user clicks a sub-tab (stops auto-default)
       let expandedGroups = new Set();  // group names expanded to show per-device status
       let view = 'console';            // 'console' | 'manage'
-      let installState = {};           // id -> { task, status, filename, detail, note, verb }
+      let deviceTaskState = {};           // id -> { task, status, filename, detail, note, verb }
       let editingLabelId = null;
       let uploadedApk = null;
       let uploadInProgress = false;
@@ -500,9 +492,7 @@
       // browser and never leaves it; only per-device results are compared here.
       let verifyApkRef = null;         // { size, cd_sha256, filename }
       let verifyApkAutoPkg = '';       // last package name auto-filled from an APK (vs typed)
-      let verifyApkState = {};         // id -> { status, detail }
       let verifyDirRef = null;         // { tree_hash, file_count, total_size, manifest?, source }
-      let verifyDirState = {};         // id -> { status, detail }
       let reconnectTimer = null;
       const RECONNECT_DELAY = 3000;
       const LOW_BATTERY_THRESHOLD = 20;
@@ -539,14 +529,12 @@
       const verifyApkName = document.getElementById('verifyApkName');
       const verifyApkPkg = document.getElementById('verifyApkPkg');
       const btnVerifyApk = document.getElementById('btnVerifyApk');
-      const verifyApkResults = document.getElementById('verifyApkResults');
       const verifyDirPath = document.getElementById('verifyDirPath');
       const verifyDirFolder = document.getElementById('verifyDirFolder');
       const verifyDirDrop = document.getElementById('verifyDirDrop');
       const verifyDirJson = document.getElementById('verifyDirJson');
       const verifyDirRefName = document.getElementById('verifyDirRefName');
       const btnVerifyDir = document.getElementById('btnVerifyDir');
-      const verifyDirResults = document.getElementById('verifyDirResults');
       const logContainer = document.getElementById('logContainer');
       const logEmpty = document.getElementById('logEmpty');
       const btnClearLog = document.getElementById('btnClearLog');
@@ -554,7 +542,10 @@
       const mgDetail = document.getElementById('mgDetail');
 
       // ---------------- Helpers ----------------
-      function esc(s) { const d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+      // textContent -> innerHTML escapes & < > but leaves quotes alone, and most callers
+      // interpolate into an attribute (title=", data-id="). A device- or server-supplied
+      // string carrying a double quote would otherwise escape the attribute.
+      function esc(s) { const d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML.replace(/"/g, '&quot;'); }
       function getDeviceId(d) { return d.device_id || d.serial_number || ''; }
       function isOnline(d) { return d.status !== 'offline'; }
       function deviceById(id) { return devices.find(function (d) { return getDeviceId(d) === id; }); }
@@ -610,7 +601,7 @@
             const cur = knownIds();
             selectedIds.forEach(function (id) { if (!cur.has(id)) selectedIds.delete(id); });
             const onlineNow = new Set(getOnlineIds());
-            Object.keys(installState).forEach(function (id) { if (!onlineNow.has(id)) delete installState[id]; });
+            Object.keys(deviceTaskState).forEach(function (id) { if (!onlineNow.has(id)) delete deviceTaskState[id]; });
             syncActiveGroupSelection();
             render();
             break;
@@ -638,15 +629,15 @@
             // Per-device companion to INSTALL_PROGRESS: the aggregate counts cannot
             // be mapped back to rows, so the server names the devices it moved.
             (msg.device_ids || []).forEach(function (id) {
-              installState[id] = { task: 'install', status: msg.state, filename: msg.apk_filename || '', detail: msg.detail || '' };
-              updateInstallCell(id);
+              deviceTaskState[id] = { task: 'install', status: msg.state, filename: msg.apk_filename || '', detail: msg.detail || '' };
+              updateTaskCell(id);
             });
             break;
           }
           case 'INSTALL_RESULT': {
             const st = msg.status === 'success' ? 'success' : 'fail';
             const detail = msg.error || msg.message || '';
-            if (msg.device_id) { installState[msg.device_id] = { task: 'install', status: st, filename: msg.apk_filename || '', detail: detail }; updateInstallCell(msg.device_id); }
+            if (msg.device_id) { deviceTaskState[msg.device_id] = { task: 'install', status: st, filename: msg.apk_filename || '', detail: detail }; updateTaskCell(msg.device_id); }
             addLog('[' + (msg.status === 'success' ? 'OK' : 'FAIL') + '] install ' + (msg.apk_filename || '-') + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), st);
             break;
           }
@@ -655,11 +646,11 @@
             const st = msg.status === 'success' ? 'success' : 'fail';
             const summary = '+' + (msg.added || 0) + ' ~' + (msg.updated || 0) + ' -' + (msg.deleted || 0);
             const detail = msg.error || msg.message || '';
-            const prev = msg.device_id ? installState[msg.device_id] : null;
+            const prev = msg.device_id ? deviceTaskState[msg.device_id] : null;
             const verb = (prev && prev.task === 'push' && prev.verb) || 'Push';
             if (msg.device_id) {
-              installState[msg.device_id] = { task: 'push', status: st, verb: verb, filename: msg.dest_path || '', note: st === 'success' ? summary : '', detail: detail };
-              updateInstallCell(msg.device_id);
+              deviceTaskState[msg.device_id] = { task: 'push', status: st, verb: verb, filename: msg.dest_path || '', note: st === 'success' ? summary : '', detail: detail };
+              updateTaskCell(msg.device_id);
             }
             const what = verb.toLowerCase();
             if (st === 'success') {
@@ -690,7 +681,7 @@
           case 'VERIFY_SENT': addLog('Verify APK command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
           case 'VERIFY_APK_RESULT': {
             const cls = verifyApkRef ? classifyApk(msg) : { status: 'error', detail: 'no local reference' };
-            if (msg.device_id) { verifyApkState[msg.device_id] = cls; renderVerifyResults(verifyApkResults, verifyApkState); }
+            if (msg.device_id) { deviceTaskState[msg.device_id] = { task: 'verify', kind: 'apk', status: cls.status, detail: cls.detail }; updateTaskCell(msg.device_id); }
             const ok = cls.status === 'match';
             addLog('[' + (ok ? 'MATCH' : 'DIFF') + '] verify ' + (msg.package_name || '-') + ' on ' + labelFor(msg.device_id) + (cls.detail ? ' - ' + cls.detail : ''), ok ? 'success' : 'fail');
             break;
@@ -698,7 +689,7 @@
           case 'VERIFY_DIR_SENT': addLog('Verify directory command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
           case 'VERIFY_DIR_RESULT': {
             const cls = verifyDirRef ? classifyDir(msg) : { status: 'error', detail: 'no local reference' };
-            if (msg.device_id) { verifyDirState[msg.device_id] = cls; renderVerifyResults(verifyDirResults, verifyDirState); }
+            if (msg.device_id) { deviceTaskState[msg.device_id] = { task: 'verify', kind: 'dir', status: cls.status, detail: cls.detail }; updateTaskCell(msg.device_id); }
             const ok = cls.status === 'match';
             addLog('[' + (ok ? 'MATCH' : 'DIFF') + '] verify dir ' + (msg.path || '-') + ' on ' + labelFor(msg.device_id) + (cls.detail ? ' - ' + cls.detail : ''), ok ? 'success' : 'fail');
             break;
@@ -783,7 +774,7 @@
             '<span class="dot ' + (off ? 'off' : '') + '"></span>' +
             '<span class="group-dev-name">' + esc(label) + '</span>' +
             '<span class="group-dev-status">' + status + '</span>' +
-            '<span class="group-dev-install" data-install-id="' + esc(serial) + '">' + installCellHtml(serial) + '</span>' +
+            '<span class="group-dev-task" data-task-id="' + esc(serial) + '">' + taskCellHtml(serial) + '</span>' +
             '</div>';
         }).join('');
       }
@@ -832,7 +823,7 @@
             '<div class="dev-cell">' + deviceCell + '</div>' +
             '<div class="dev-status">' + status + '</div>' +
             '<div class="dev-battery">' + batteryHtml(d) + '</div>' +
-            '<div class="dev-install" data-install-id="' + esc(id) + '">' + installCellHtml(id) + '</div>' +
+            '<div class="dev-task" data-task-id="' + esc(id) + '">' + taskCellHtml(id) + '</div>' +
             '</div>';
         });
         html += '</div>';
@@ -841,7 +832,9 @@
         return html;
       }
 
-      // The cell shows whichever job last touched the device, install or push.
+      // The cell shows whichever job last touched the device: install, push or verify.
+      // A later job overwrites an earlier one, exactly as a second install would; the log
+      // keeps the full history either way.
       //
       // An install's four live states mirror the server's install job: a device waits
       // for a transfer slot (queued), pulls the APK (transferring), installs it locally
@@ -849,9 +842,21 @@
       // no such phases — it is not throttled, so the server holds no per-device state
       // for it and cannot broadcast transitions. The console paints `pushing` on
       // dispatch and resolves it on PUSH_FILES_RESULT.
-      function installCellHtml(id) {
-        const st = installState[id];
+      function taskCellHtml(id) {
+        const st = deviceTaskState[id];
         if (!st) return '<span class="ins-none">—</span>';
+        if (st.task === 'verify') {
+          // A verify verdict is reached in the browser, not on the device: the device
+          // returns hashes and classifyApk()/classifyDir() decide. The column has room for
+          // the verdict only — `missing 3 · added 0 · changed 1` lives in the tooltip and
+          // the log, where it can be read without truncation.
+          const what = st.kind === 'dir' ? 'directory' : 'APK';
+          if (st.status === 'verifying') return '<span class="ins-installing"><span class="spinner">⟳</span> Verifying…</span>';
+          if (st.status === 'match') return '<span class="ins-success" title="' + esc(what + ': ' + (st.detail || 'match')) + '">✓ match</span>';
+          if (st.status === 'notfound') return '<span class="ins-fail" title="' + esc(st.detail || '') + '">✗ not found</span>';
+          if (st.status === 'error') return '<span class="ins-fail" title="' + esc(st.detail || '') + '">✗ error</span>';
+          return '<span class="ins-fail" title="' + esc(what + ': ' + (st.detail || 'mismatch')) + '">✗ mismatch</span>';
+        }
         if (st.task === 'push') {
           // `verb` is set when the console dispatches, and carried onto the result so a synced
           // device does not report itself as "pushed". PUSH_FILES_RESULT does not name the
@@ -868,12 +873,12 @@
         return '<span class="ins-fail" title="' + esc(st.detail || '') + '">✗ failed</span>' + (st.detail ? ' <span class="ins-none">' + esc(st.detail) + '</span>' : '');
       }
 
-      function updateInstallCell(id) {
+      function updateTaskCell(id) {
         // Refresh every matching install cell currently rendered: the Devices-tab
         // row and/or the expanded-group per-device rows on the Groups tab.
         if (view !== 'console') return;
-        const sel = '[data-install-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]';
-        targetsBody.querySelectorAll(sel).forEach(function (cell) { cell.innerHTML = installCellHtml(id); });
+        const sel = '[data-task-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]';
+        targetsBody.querySelectorAll(sel).forEach(function (cell) { cell.innerHTML = taskCellHtml(id); });
       }
 
       function renderActions() {
@@ -981,7 +986,7 @@
           if (!wsSend({ type: 'INSTALL_APK', target_devices: online, apk_url: apk.apk_url, apk_filename: apk.apk_filename }, 'install')) return;
           // Optimistic first paint only: every target really does start out waiting
           // for a transfer slot. The server's INSTALL_DEVICE_STATE drives it from here.
-          online.forEach(function (id) { installState[id] = { task: 'install', status: 'queued', filename: apk.apk_filename, detail: '' }; updateInstallCell(id); });
+          online.forEach(function (id) { deviceTaskState[id] = { task: 'install', status: 'queued', filename: apk.apk_filename, detail: '' }; updateTaskCell(id); });
           addLog('Installing ' + apk.apk_filename + ' on ' + online.length + ' device(s)', 'info');
           // Force a fresh pick next time (LAN/non-secure context cannot detect a local rebuild).
           apkFile.value = ''; uploadedApk = null; apkName.textContent = 'No APK selected'; updateButtons();
@@ -1072,7 +1077,7 @@
             // Optimistic first paint: the fan-out is not throttled, so every online target
             // really is working from here until its PUSH_FILES_RESULT arrives, or DEVICE_LIST
             // drops it as offline.
-            online.forEach(function (id) { installState[id] = { task: 'push', status: 'pushing', verb: cfg.verb, filename: dest, note: '', detail: '' }; updateInstallCell(id); });
+            online.forEach(function (id) { deviceTaskState[id] = { task: 'push', status: 'pushing', verb: cfg.verb, filename: dest, note: '', detail: '' }; updateTaskCell(id); });
             addLog(cfg.verb + 'ing ' + bundle.bundle_filename + ' → ' + dest + ' on ' + online.length + ' device(s)', 'info');
             // Force a fresh pick next time (LAN/non-secure context cannot detect a local change).
             reset();
@@ -1701,23 +1706,6 @@
         return { status: 'mismatch', detail: detail };
       }
 
-      function verifyStatusHtml(st) {
-        switch (st.status) {
-          case 'verifying': return '<span class="verify-stat ins-installing"><span class="spinner">⟳</span> Verifying…</span>';
-          case 'match': return '<span class="verify-stat ins-success">✓ match</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
-          case 'mismatch': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ mismatch</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
-          case 'notfound': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ ' + esc(st.detail || 'not found') + '</span>';
-          case 'error': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ error</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
-          default: return '<span class="verify-stat ins-none">—</span>';
-        }
-      }
-      function renderVerifyResults(container, stateMap) {
-        const ids = Object.keys(stateMap);
-        container.innerHTML = ids.length ? ids.map(function (id) {
-          return '<div class="verify-row"><span class="verify-dev">' + esc(labelFor(id)) + '</span>' + verifyStatusHtml(stateMap[id]) + '</div>';
-        }).join('') : '';
-      }
-
       // ---- reference selection + command dispatch ----
       // Carrying a package name over from a previously picked APK would silently verify the
       // new reference against the old package, so drop what we filled in ourselves. A name
@@ -1755,9 +1743,7 @@
         const online = onlineTargets(Array.from(selectedIds));
         if (!online.length) { addLog('No online devices selected to verify', 'warn'); return; }
         if (!wsSend({ type: 'VERIFY_APK', target_devices: online, package_name: pkg }, 'verify APK')) return;
-        verifyApkState = {};
-        online.forEach(function (id) { verifyApkState[id] = { status: 'verifying', detail: '' }; });
-        renderVerifyResults(verifyApkResults, verifyApkState);
+        online.forEach(function (id) { deviceTaskState[id] = { task: 'verify', kind: 'apk', status: 'verifying', detail: '' }; updateTaskCell(id); });
         addLog('Verifying ' + pkg + ' against ' + verifyApkRef.filename + ' on ' + online.length + ' device(s)', 'info');
       }
       function osMetadataNote(count) { return count ? ' · ' + count + ' OS metadata excluded' : ''; }
@@ -1820,9 +1806,7 @@
         const online = onlineTargets(Array.from(selectedIds));
         if (!online.length) { addLog('No online devices selected to verify', 'warn'); return; }
         if (!wsSend({ type: 'VERIFY_DIR', target_devices: online, path: path }, 'verify directory')) return;
-        verifyDirState = {};
-        online.forEach(function (id) { verifyDirState[id] = { status: 'verifying', detail: '' }; });
-        renderVerifyResults(verifyDirResults, verifyDirState);
+        online.forEach(function (id) { deviceTaskState[id] = { task: 'verify', kind: 'dir', status: 'verifying', detail: '' }; updateTaskCell(id); });
         addLog('Verifying ' + path + ' against local reference on ' + online.length + ' device(s)', 'info');
       }
 

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -176,6 +176,16 @@
     .ins-none { color: var(--text-dim); }
     .spinner { display: inline-block; animation: spin 1s linear infinite; }
 
+    /* Verify (integrity check) — per-device results panel inside the Actions column */
+    .verify-hint { color: var(--text-muted); font-size: 11px; margin-top: 8px; line-height: 1.4; }
+    .verify-hint code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; color: var(--text-secondary); }
+    .verify-results { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+    .verify-row { display: flex; align-items: baseline; gap: 8px; font-size: 12px; padding: 3px 0; border-top: 1px solid #232a3d; }
+    .verify-row:first-child { border-top: none; }
+    .verify-dev { font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto; }
+    .verify-stat { margin-left: auto; text-align: right; }
+    .verify-detail { color: var(--text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; }
+
     /* Select boxes */
     .selbox { width: 16px; height: 16px; border-radius: 4px; border: 1.5px solid #41475f; display: flex; align-items: center; justify-content: center; cursor: pointer; flex-shrink: 0; color: #fff; font-size: 11px; font-weight: 800; }
     .selbox.on, .selbox.mixed { background: var(--accent); border-color: var(--accent); }
@@ -404,6 +414,38 @@
                 </div>
               </div>
             </div>
+            <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="verifyApk">
+              <div class="cmd-head" data-act="toggleCmd"><span>Verify APK</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <div class="file-row">
+                  <label class="file-pick" for="verifyApkFile">Choose APK</label>
+                  <input type="file" id="verifyApkFile" accept=".apk,application/vnd.android.package-archive" hidden>
+                  <span class="file-name" id="verifyApkName">No reference APK</span>
+                </div>
+                <input type="text" class="field" id="verifyApkPkg" placeholder="com.example.app (package name)">
+                <button class="btn btn-primary" id="btnVerifyApk" disabled>Verify on Selected</button>
+                <div class="verify-hint">Reference is hashed locally in your browser — nothing is uploaded.</div>
+                <div class="verify-results" id="verifyApkResults"></div>
+              </div>
+            </div>
+            <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="verifyDir">
+              <div class="cmd-head" data-act="toggleCmd"><span>Verify Directory</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <input type="text" class="field" id="verifyDirPath" placeholder="/sdcard/content (device path)">
+                <div class="file-row">
+                  <label class="file-pick" for="verifyDirFolder">Choose Folder</label>
+                  <input type="file" id="verifyDirFolder" webkitdirectory directory hidden>
+                  <label class="file-pick" for="verifyDirJson">or Hash JSON</label>
+                  <input type="file" id="verifyDirJson" accept=".json,application/json" hidden>
+                  <span class="file-name" id="verifyDirRefName">No reference</span>
+                </div>
+                <button class="btn btn-primary" id="btnVerifyDir" disabled>Verify on Selected</button>
+                <div class="verify-hint">Large trees hash faster with <code>styly-mdm hash &lt;path&gt;</code> — load its JSON here. Shared storage only.</div>
+                <div class="verify-results" id="verifyDirResults"></div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -451,6 +493,12 @@
       let editingLabelId = null;
       let uploadedApk = null;
       let uploadInProgress = false;
+      // Integrity verification (issue #37). The reference is computed locally in the
+      // browser and never leaves it; only per-device results are compared here.
+      let verifyApkRef = null;         // { size, cd_sha256, filename }
+      let verifyApkState = {};         // id -> { status, detail }
+      let verifyDirRef = null;         // { tree_hash, file_count, total_size, manifest?, source }
+      let verifyDirState = {};         // id -> { status, detail }
       let reconnectTimer = null;
       const RECONNECT_DELAY = 3000;
       const LOW_BATTERY_THRESHOLD = 20;
@@ -483,6 +531,17 @@
       const startupExtra = document.getElementById('startupExtra');
       const btnStartupSet = document.getElementById('btnStartupSet');
       const btnStartupClear = document.getElementById('btnStartupClear');
+      const verifyApkFile = document.getElementById('verifyApkFile');
+      const verifyApkName = document.getElementById('verifyApkName');
+      const verifyApkPkg = document.getElementById('verifyApkPkg');
+      const btnVerifyApk = document.getElementById('btnVerifyApk');
+      const verifyApkResults = document.getElementById('verifyApkResults');
+      const verifyDirPath = document.getElementById('verifyDirPath');
+      const verifyDirFolder = document.getElementById('verifyDirFolder');
+      const verifyDirJson = document.getElementById('verifyDirJson');
+      const verifyDirRefName = document.getElementById('verifyDirRefName');
+      const btnVerifyDir = document.getElementById('btnVerifyDir');
+      const verifyDirResults = document.getElementById('verifyDirResults');
       const logContainer = document.getElementById('logContainer');
       const logEmpty = document.getElementById('logEmpty');
       const btnClearLog = document.getElementById('btnClearLog');
@@ -621,6 +680,22 @@
           case 'STARTUP_APP_RESULT': {
             const st = msg.status === 'success' ? 'success' : 'fail';
             addLog('[Startup ' + (msg.status === 'success' ? 'OK' : 'FAIL') + '] ' + (msg.package_name || '') + (msg.device_id ? ' on ' + labelFor(msg.device_id) : '') + (msg.error ? ' - ' + msg.error : ''), st);
+            break;
+          }
+          case 'VERIFY_SENT': addLog('Verify APK command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
+          case 'VERIFY_APK_RESULT': {
+            const cls = verifyApkRef ? classifyApk(msg) : { status: 'error', detail: 'no local reference' };
+            if (msg.device_id) { verifyApkState[msg.device_id] = cls; renderVerifyResults(verifyApkResults, verifyApkState); }
+            const ok = cls.status === 'match';
+            addLog('[' + (ok ? 'MATCH' : 'DIFF') + '] verify ' + (msg.package_name || '-') + ' on ' + labelFor(msg.device_id) + (cls.detail ? ' - ' + cls.detail : ''), ok ? 'success' : 'fail');
+            break;
+          }
+          case 'VERIFY_DIR_SENT': addLog('Verify directory command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
+          case 'VERIFY_DIR_RESULT': {
+            const cls = verifyDirRef ? classifyDir(msg) : { status: 'error', detail: 'no local reference' };
+            if (msg.device_id) { verifyDirState[msg.device_id] = cls; renderVerifyResults(verifyDirResults, verifyDirState); }
+            const ok = cls.status === 'match';
+            addLog('[' + (ok ? 'MATCH' : 'DIFF') + '] verify dir ' + (msg.path || '-') + ' on ' + labelFor(msg.device_id) + (cls.detail ? ' - ' + cls.detail : ''), ok ? 'success' : 'fail');
             break;
           }
           case 'ERROR': addLog('[ERROR] ' + (msg.message || 'Unknown error'), 'fail'); break;
@@ -824,6 +899,8 @@
         btnStartupClear.disabled = !has;
         pushPanel.refreshButton(has);
         syncPanel.refreshButton(has);
+        btnVerifyApk.disabled = !verifyApkRef || verifyApkPkg.value.trim() === '' || !has;
+        btnVerifyDir.disabled = !verifyDirRef || verifyDirPath.value.trim() === '' || !has;
       }
 
       // ---------------- Selection actions ----------------
@@ -1213,6 +1290,250 @@
         return v.toFixed(i === 0 ? 0 : 1) + ' ' + u[i];
       }
 
+      // ---------------- Integrity verification (issue #37) ----------------
+      // Pure-JS SHA-256 (the console is served over plain http://<LAN-IP>, a non-secure
+      // context, so crypto.subtle is unavailable). This implementation + the ZIP/tree
+      // algorithms below are byte-for-byte identical to the Python (styly-mdm hash) and
+      // Kotlin (device) implementations — verified with a cross-language harness.
+      const SHA256_K = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+      ];
+      function Sha256() {
+        this.h = new Int32Array([0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]);
+        this.buf = new Uint8Array(64); this.bufLen = 0; this.total = 0; this.w = new Int32Array(64);
+      }
+      Sha256.prototype._compress = function (block, offset) {
+        const w = this.w; let i;
+        for (i = 0; i < 16; i++) {
+          w[i] = (block[offset + i * 4] << 24) | (block[offset + i * 4 + 1] << 16) | (block[offset + i * 4 + 2] << 8) | (block[offset + i * 4 + 3]);
+        }
+        for (i = 16; i < 64; i++) {
+          const x = w[i - 15], s0 = ((x >>> 7) | (x << 25)) ^ ((x >>> 18) | (x << 14)) ^ (x >>> 3);
+          const y = w[i - 2], s1 = ((y >>> 17) | (y << 15)) ^ ((y >>> 19) | (y << 13)) ^ (y >>> 10);
+          w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+        }
+        let a = this.h[0], b = this.h[1], c = this.h[2], d = this.h[3], e = this.h[4], f = this.h[5], g = this.h[6], hh = this.h[7];
+        for (i = 0; i < 64; i++) {
+          const S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+          const ch = (e & f) ^ (~e & g);
+          const t1 = (hh + S1 + ch + SHA256_K[i] + w[i]) | 0;
+          const S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+          const maj = (a & b) ^ (a & c) ^ (b & c);
+          const t2 = (S0 + maj) | 0;
+          hh = g; g = f; f = e; e = (d + t1) | 0; d = c; c = b; b = a; a = (t1 + t2) | 0;
+        }
+        this.h[0] = (this.h[0] + a) | 0; this.h[1] = (this.h[1] + b) | 0; this.h[2] = (this.h[2] + c) | 0; this.h[3] = (this.h[3] + d) | 0;
+        this.h[4] = (this.h[4] + e) | 0; this.h[5] = (this.h[5] + f) | 0; this.h[6] = (this.h[6] + g) | 0; this.h[7] = (this.h[7] + hh) | 0;
+      };
+      Sha256.prototype.update = function (data) {
+        this.total += data.length; let offset = 0; const len = data.length;
+        if (this.bufLen > 0) {
+          while (offset < len && this.bufLen < 64) { this.buf[this.bufLen++] = data[offset++]; }
+          if (this.bufLen === 64) { this._compress(this.buf, 0); this.bufLen = 0; }
+        }
+        while (len - offset >= 64) { this._compress(data, offset); offset += 64; }
+        while (offset < len) { this.buf[this.bufLen++] = data[offset++]; }
+        return this;
+      };
+      Sha256.prototype.hex = function () {
+        const bitLenHi = Math.floor(this.total / 0x20000000), bitLenLo = (this.total * 8) >>> 0;
+        const pad = [0x80];
+        const restLen = (this.bufLen + 1) % 64, padZeros = (restLen <= 56) ? (56 - restLen) : (120 - restLen);
+        for (let i = 0; i < padZeros; i++) pad.push(0x00);
+        pad.push((bitLenHi >>> 24) & 0xff, (bitLenHi >>> 16) & 0xff, (bitLenHi >>> 8) & 0xff, bitLenHi & 0xff);
+        pad.push((bitLenLo >>> 24) & 0xff, (bitLenLo >>> 16) & 0xff, (bitLenLo >>> 8) & 0xff, bitLenLo & 0xff);
+        this.update(new Uint8Array(pad));
+        let out = '';
+        for (let j = 0; j < 8; j++) { out += ('00000000' + ((this.h[j]) >>> 0).toString(16)).slice(-8); }
+        return out;
+      };
+
+      const EOCD_MIN = 22, MAX_COMMENT = 0xffff, ZIP64_SENTINEL = 0xffffffff, HASH_CHUNK = 4 * 1024 * 1024;
+      function findEocd(tail, fileLen, tailStart, view) {
+        for (let i = tail.length - EOCD_MIN; i >= 0; i--) {
+          if (tail[i] === 0x50 && tail[i + 1] === 0x4b && tail[i + 2] === 0x05 && tail[i + 3] === 0x06) {
+            const commentLen = view.getUint16(i + 20, true);
+            if (tailStart + i + EOCD_MIN + commentLen === fileLen) return i;
+          }
+        }
+        throw new Error('End Of Central Directory record not found (not a valid ZIP/APK?)');
+      }
+      // size + SHA-256 of the ZIP Central-Directory region [CD_offset .. EOF]. Reads only
+      // the tail + CD region, so a 1 GB+ APK is not loaded into memory and nothing uploads.
+      async function apkCdDigest(file) {
+        const size = file.size;
+        const readLen = Math.min(size, EOCD_MIN + MAX_COMMENT);
+        const tailStart = size - readLen;
+        const tailBuf = new Uint8Array(await file.slice(tailStart, size).arrayBuffer());
+        const view = new DataView(tailBuf.buffer, tailBuf.byteOffset, tailBuf.byteLength);
+        const eocdOff = findEocd(tailBuf, size, tailStart, view);
+        const cdOffset = view.getUint32(eocdOff + 16, true);
+        if (cdOffset === ZIP64_SENTINEL) throw new Error('zip64 archives are not supported');
+        const h = new Sha256();
+        for (let pos = cdOffset; pos < size; pos += HASH_CHUNK) {
+          h.update(new Uint8Array(await file.slice(pos, Math.min(pos + HASH_CHUNK, size)).arrayBuffer()));
+        }
+        return { size: size, cd_sha256: h.hex() };
+      }
+      async function fileSha256(file) {
+        const h = new Sha256();
+        for (let pos = 0; pos < file.size; pos += HASH_CHUNK) {
+          h.update(new Uint8Array(await file.slice(pos, Math.min(pos + HASH_CHUNK, file.size)).arrayBuffer()));
+        }
+        return h.hex();
+      }
+      // A <input webkitdirectory> pick prefixes webkitRelativePath with the picked folder
+      // name; strip it so the manifest mirrors the folder's contents (matches the device).
+      function stripTopLevel(relPath) { const i = relPath.indexOf('/'); return i >= 0 ? relPath.slice(i + 1) : relPath; }
+      function utf8Bytes(s) { return new TextEncoder().encode(s); }
+      function utf8Compare(a, b) {
+        const ea = utf8Bytes(a), eb = utf8Bytes(b), n = Math.min(ea.length, eb.length);
+        for (let i = 0; i < n; i++) { if (ea[i] !== eb[i]) return ea[i] - eb[i]; }
+        return ea.length - eb.length;
+      }
+      async function dirManifest(fileList, onProgress) {
+        const files = [];
+        for (let k = 0; k < fileList.length; k++) { if (fileList[k].webkitRelativePath) files.push(fileList[k]); }
+        const entries = [];
+        for (let i = 0; i < files.length; i++) {
+          const rel = stripTopLevel(files[i].webkitRelativePath);
+          if (!rel) continue;
+          entries.push({ relative_path: rel, size: files[i].size, sha256: await fileSha256(files[i]) });
+          if (onProgress) onProgress(i + 1, files.length);
+        }
+        entries.sort(function (x, y) { return utf8Compare(x.relative_path, y.relative_path); });
+        const h = new Sha256(); let totalSize = 0; const enc = new TextEncoder();
+        for (let j = 0; j < entries.length; j++) {
+          totalSize += entries[j].size;
+          h.update(enc.encode(entries[j].relative_path + '\n' + entries[j].size + '\n' + entries[j].sha256 + '\n'));
+        }
+        return { tree_hash: h.hex(), file_count: entries.length, total_size: totalSize, manifest: entries };
+      }
+
+      // ---- comparison of a device result against the local reference ----
+      function classifyApk(msg) {
+        if (msg.error) return { status: 'error', detail: String(msg.error) };
+        if (!msg.found) return { status: 'notfound', detail: 'not installed' };
+        const sizeOk = Number(msg.size) === Number(verifyApkRef.size);
+        const cdOk = msg.cd_sha256 === verifyApkRef.cd_sha256;
+        if (sizeOk && cdOk) return { status: 'match', detail: 'v' + (msg.version_name || '?') };
+        const bits = [];
+        if (!sizeOk) bits.push('size ' + msg.size + ' vs ' + verifyApkRef.size);
+        if (!cdOk) bits.push('CD digest differs');
+        if (msg.version_name != null || msg.version_code != null) bits.push('device v' + (msg.version_name || '?') + ' (' + (msg.version_code != null ? msg.version_code : '?') + ')');
+        if (msg.signer_sha256) bits.push('signer ' + String(msg.signer_sha256).slice(0, 12) + '…');
+        return { status: 'mismatch', detail: bits.join(' · ') };
+      }
+      function diffManifests(refList, devList) {
+        const refMap = {}, devMap = {};
+        refList.forEach(function (e) { refMap[e.relative_path] = e; });
+        devList.forEach(function (e) { devMap[e.relative_path] = e; });
+        const missing = [], added = [], changed = [];
+        Object.keys(refMap).forEach(function (p) {
+          if (!(p in devMap)) missing.push(p);
+          else if (devMap[p].sha256 !== refMap[p].sha256 || Number(devMap[p].size) !== Number(refMap[p].size)) changed.push(p);
+        });
+        Object.keys(devMap).forEach(function (p) { if (!(p in refMap)) added.push(p); });
+        return { missing: missing, added: added, changed: changed };
+      }
+      function classifyDir(msg) {
+        if (msg.error) return { status: 'error', detail: String(msg.error) };
+        if (msg.found === false) return { status: 'notfound', detail: 'path not found' };
+        if (msg.tree_hash === verifyDirRef.tree_hash) return { status: 'match', detail: (msg.file_count != null ? msg.file_count + ' files' : '') };
+        let detail;
+        if (verifyDirRef.manifest && Array.isArray(msg.manifest)) {
+          const d = diffManifests(verifyDirRef.manifest, msg.manifest);
+          detail = 'missing ' + d.missing.length + ' · added ' + d.added.length + ' · changed ' + d.changed.length;
+        } else {
+          detail = 'tree differs (' + (msg.file_count != null ? msg.file_count : '?') + ' files on device vs ' + verifyDirRef.file_count + ' local)';
+        }
+        return { status: 'mismatch', detail: detail };
+      }
+
+      function verifyStatusHtml(st) {
+        switch (st.status) {
+          case 'verifying': return '<span class="verify-stat ins-installing"><span class="spinner">⟳</span> Verifying…</span>';
+          case 'match': return '<span class="verify-stat ins-success">✓ match</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
+          case 'mismatch': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ mismatch</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
+          case 'notfound': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ ' + esc(st.detail || 'not found') + '</span>';
+          case 'error': return '<span class="verify-stat ins-fail" title="' + esc(st.detail || '') + '">✗ error</span>' + (st.detail ? ' <span class="verify-detail">' + esc(st.detail) + '</span>' : '');
+          default: return '<span class="verify-stat ins-none">—</span>';
+        }
+      }
+      function renderVerifyResults(container, stateMap) {
+        const ids = Object.keys(stateMap);
+        container.innerHTML = ids.length ? ids.map(function (id) {
+          return '<div class="verify-row"><span class="verify-dev">' + esc(labelFor(id)) + '</span>' + verifyStatusHtml(stateMap[id]) + '</div>';
+        }).join('') : '';
+      }
+
+      // ---- reference selection + command dispatch ----
+      async function onVerifyApkFile() {
+        verifyApkRef = null;
+        const f = verifyApkFile.files[0];
+        if (!f) { verifyApkName.textContent = 'No reference APK'; updateButtons(); return; }
+        verifyApkName.textContent = 'Hashing ' + f.name + '…'; updateButtons();
+        try {
+          const r = await apkCdDigest(f);
+          verifyApkRef = { size: r.size, cd_sha256: r.cd_sha256, filename: f.name };
+          verifyApkName.textContent = 'Ref: ' + f.name + ' (' + formatBytes(r.size) + ')';
+        } catch (e) { verifyApkName.textContent = 'Error: ' + e.message; }
+        updateButtons();
+      }
+      function sendVerifyApk() {
+        const pkg = verifyApkPkg.value.trim();
+        if (!verifyApkRef || !pkg) return;
+        const online = onlineTargets(Array.from(selectedIds));
+        if (!online.length) { addLog('No online devices selected to verify', 'warn'); return; }
+        if (!wsSend({ type: 'VERIFY_APK', target_devices: online, package_name: pkg }, 'verify APK')) return;
+        verifyApkState = {};
+        online.forEach(function (id) { verifyApkState[id] = { status: 'verifying', detail: '' }; });
+        renderVerifyResults(verifyApkResults, verifyApkState);
+        addLog('Verifying ' + pkg + ' against ' + verifyApkRef.filename + ' on ' + online.length + ' device(s)', 'info');
+      }
+      async function onVerifyDirFolder() {
+        verifyDirRef = null; verifyDirJson.value = '';
+        const files = verifyDirFolder.files;
+        if (!files || !files.length) { verifyDirRefName.textContent = 'No reference'; updateButtons(); return; }
+        verifyDirRefName.textContent = 'Hashing…'; updateButtons();
+        try {
+          const r = await dirManifest(files, function (done, total) { verifyDirRefName.textContent = 'Hashing ' + done + '/' + total + '…'; });
+          verifyDirRef = { tree_hash: r.tree_hash, file_count: r.file_count, total_size: r.total_size, manifest: r.manifest, source: 'folder' };
+          verifyDirRefName.textContent = 'Ref: ' + r.file_count + ' files (' + formatBytes(r.total_size) + ')';
+        } catch (e) { verifyDirRefName.textContent = 'Error: ' + e.message; }
+        updateButtons();
+      }
+      async function onVerifyDirJson() {
+        verifyDirRef = null; verifyDirFolder.value = '';
+        const f = verifyDirJson.files[0];
+        if (!f) { verifyDirRefName.textContent = 'No reference'; updateButtons(); return; }
+        try {
+          const obj = JSON.parse(await f.text());
+          if (!obj || typeof obj.tree_hash !== 'string') throw new Error('missing tree_hash');
+          verifyDirRef = { tree_hash: obj.tree_hash, file_count: obj.file_count, total_size: obj.total_size, manifest: obj.manifest, source: 'json' };
+          verifyDirRefName.textContent = 'Ref (CLI): ' + f.name + (obj.file_count != null ? ' — ' + obj.file_count + ' files' : '');
+        } catch (e) { verifyDirRefName.textContent = 'Invalid hash JSON: ' + e.message; }
+        updateButtons();
+      }
+      function sendVerifyDir() {
+        const path = verifyDirPath.value.trim();
+        if (!verifyDirRef || !path) return;
+        const online = onlineTargets(Array.from(selectedIds));
+        if (!online.length) { addLog('No online devices selected to verify', 'warn'); return; }
+        if (!wsSend({ type: 'VERIFY_DIR', target_devices: online, path: path }, 'verify directory')) return;
+        verifyDirState = {};
+        online.forEach(function (id) { verifyDirState[id] = { status: 'verifying', detail: '' }; });
+        renderVerifyResults(verifyDirResults, verifyDirState);
+        addLog('Verifying ' + path + ' against local reference on ' + online.length + ' device(s)', 'info');
+      }
+
       // ---------------- Event wiring ----------------
       // Sub-tabs
       tabGroups.addEventListener('click', function () { targetTab = 'groups'; userPickedTab = true; render(); });
@@ -1268,6 +1589,13 @@
       btnLaunch.addEventListener('click', sendLaunch);
       btnStartupSet.addEventListener('click', sendSetStartup);
       btnStartupClear.addEventListener('click', sendClearStartup);
+      verifyApkFile.addEventListener('change', onVerifyApkFile);
+      verifyApkPkg.addEventListener('input', updateButtons);
+      btnVerifyApk.addEventListener('click', sendVerifyApk);
+      verifyDirFolder.addEventListener('change', onVerifyDirFolder);
+      verifyDirJson.addEventListener('change', onVerifyDirJson);
+      verifyDirPath.addEventListener('input', updateButtons);
+      btnVerifyDir.addEventListener('click', sendVerifyDir);
       btnClearLog.addEventListener('click', function () { logContainer.innerHTML = ''; logContainer.appendChild(logEmpty); logEmpty.style.display = 'block'; });
 
       // Command sections accordion: only one open at a time (matches the original

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -227,6 +227,8 @@
     .field:focus { outline: none; border-color: var(--accent); }
     .field::placeholder { color: var(--text-dim); }
     .field + .field { margin-top: 7px; }
+    .dropzone { padding: 14px 10px; margin-bottom: 8px; background: var(--bg-card); border: 1px dashed var(--border); border-radius: 6px; text-align: center; font-size: 12px; color: var(--text-muted); transition: border-color .12s, background .12s; }
+    .dropzone.over { border-color: var(--accent, #6b8afd); border-style: solid; background: var(--bg-tertiary); color: var(--text-primary); }
     .file-row { display: flex; align-items: center; gap: 9px; padding: 8px 10px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px; }
     .file-pick { background: var(--bg-tertiary); border-radius: 5px; padding: 5px 11px; font-size: 12px; color: #cfd3e3; cursor: pointer; white-space: nowrap; }
     .file-name { font-size: 12px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -434,6 +436,7 @@
               <div class="cmd-head" data-act="toggleCmd"><span>Verify Directory</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
                 <input type="text" class="field" id="verifyDirPath" placeholder="/sdcard/content (device path)">
+                <div class="dropzone" id="verifyDirDrop">Drop the reference folder here</div>
                 <div class="file-row">
                   <label class="file-pick" for="verifyDirFolder">Choose Folder</label>
                   <input type="file" id="verifyDirFolder" webkitdirectory directory hidden>
@@ -442,7 +445,7 @@
                   <span class="file-name" id="verifyDirRefName">No reference</span>
                 </div>
                 <button class="btn btn-primary" id="btnVerifyDir" disabled>Verify on Selected</button>
-                <div class="verify-hint">Large trees hash faster with <code>styly-mdm hash &lt;path&gt;</code> — load its JSON here. Shared storage only.</div>
+                <div class="verify-hint">Reference is hashed locally in your browser — nothing is uploaded. Dropping a folder skips the &ldquo;Upload N files&rdquo; prompt that Chrome always shows for <em>Choose Folder</em>. Large trees hash faster with <code>styly-mdm hash &lt;path&gt;</code> — load its JSON here. Shared storage only.</div>
                 <div class="verify-results" id="verifyDirResults"></div>
               </div>
             </div>
@@ -539,6 +542,7 @@
       const verifyApkResults = document.getElementById('verifyApkResults');
       const verifyDirPath = document.getElementById('verifyDirPath');
       const verifyDirFolder = document.getElementById('verifyDirFolder');
+      const verifyDirDrop = document.getElementById('verifyDirDrop');
       const verifyDirJson = document.getElementById('verifyDirJson');
       const verifyDirRefName = document.getElementById('verifyDirRefName');
       const btnVerifyDir = document.getElementById('btnVerifyDir');
@@ -1357,6 +1361,10 @@
       };
 
       const EOCD_MIN = 22, MAX_COMMENT = 0xffff, ZIP64_SENTINEL = 0xffffffff, HASH_CHUNK = 4 * 1024 * 1024;
+      // Mirrors MAX_VERIFY_DIR_ENTRIES on the device. The depth cap has no device counterpart:
+      // it stops a symlinked directory cycle, which the device walk instead avoids by skipping
+      // symlinks outright (the Entries API gives us no way to recognize one).
+      const MAX_VERIFY_DIR_ENTRIES = 50000, MAX_VERIFY_DIR_DEPTH = 64;
       const CD_SIG = 0x02014b50, LFH_SIG = 0x04034b50, STORED = 0, DEFLATED = 8;
       function findEocd(tail, fileLen, tailStart, view) {
         for (let i = tail.length - EOCD_MIN; i >= 0; i--) {
@@ -1524,23 +1532,112 @@
         for (let i = 0; i < n; i++) { if (ea[i] !== eb[i]) return ea[i] - eb[i]; }
         return ea.length - eb.length;
       }
-      async function dirManifest(fileList, onProgress) {
-        const files = [];
-        for (let k = 0; k < fileList.length; k++) { if (fileList[k].webkitRelativePath) files.push(fileList[k]); }
+      // Mirrors integrity.is_os_metadata() in Python — the two must agree exactly, or a
+      // reference built here and one built by `styly-mdm hash` would hash the same tree
+      // differently. The list stays narrow on purpose: `.git/`, Unity `.meta` and dotfiles
+      // at large are content, and silently dropping content is far worse than keeping a
+      // stray `.DS_Store`.
+      const OS_METADATA_NAMES = ['.ds_store', 'thumbs.db', 'ehthumbs.db', 'desktop.ini', '.directory', '.apdisk', '.volumeicon.icns'];
+      const OS_METADATA_DIRS = ['.spotlight-v100', '.trashes', '.fseventsd', '.temporaryitems', '.documentrevisions-v100', '__macosx', '$recycle.bin'];
+      function isOsMetadata(relPath) {
+        const segs = relPath.split('/');
+        for (let i = 0; i < segs.length; i++) {
+          const low = segs[i].toLowerCase();
+          if (OS_METADATA_NAMES.indexOf(low) >= 0 || OS_METADATA_DIRS.indexOf(low) >= 0) return true;
+          if (low.indexOf('._') === 0) return true;       // AppleDouble resource forks
+          if (low.indexOf('.trash-') === 0) return true;   // Linux per-user trash
+        }
+        return false;
+      }
+      // Both reference sources (dropped folder, picked folder) normalize to the same
+      // [{relative_path, file}] shape, so a single fold produces the tree hash and the
+      // two paths cannot drift apart. OS metadata is dropped here, in the one place both
+      // paths pass through: `push files` strips it on the way into the bundle, so a device
+      // never has it, and a reference that kept it would report a permanent "missing N"
+      // against a device that is in fact identical.
+      async function manifestFromFiles(picked, onProgress) {
+        const content = [];
+        let excludedCount = 0;
+        for (let k = 0; k < picked.length; k++) {
+          if (!picked[k].relative_path) continue;
+          if (isOsMetadata(picked[k].relative_path)) { excludedCount++; continue; }
+          content.push(picked[k]);
+        }
+        let pendingBytes = 0;
+        for (let k = 0; k < content.length; k++) pendingBytes += content[k].file.size;
         const entries = [];
-        for (let i = 0; i < files.length; i++) {
-          const rel = stripTopLevel(files[i].webkitRelativePath);
-          if (!rel) continue;
-          entries.push({ relative_path: rel, size: files[i].size, sha256: await fileSha256(files[i]) });
-          if (onProgress) onProgress(i + 1, files.length);
+        let doneBytes = 0;
+        for (let i = 0; i < content.length; i++) {
+          entries.push({ relative_path: content[i].relative_path, size: content[i].file.size, sha256: await fileSha256(content[i].file) });
+          doneBytes += content[i].file.size;
+          if (onProgress) onProgress(i + 1, content.length, doneBytes, pendingBytes);
         }
         entries.sort(function (x, y) { return utf8Compare(x.relative_path, y.relative_path); });
-        const h = new Sha256(); let totalSize = 0; const enc = new TextEncoder();
+        const folded = foldTreeHash(entries);
+        return { tree_hash: folded.tree_hash, file_count: folded.file_count, total_size: folded.total_size, manifest: entries, excluded_count: excludedCount };
+      }
+      // The one definition of tree_hash on this side of the wire. `entries` must already be
+      // sorted by the UTF-8 byte order of relative_path — as the reference builder sorts them
+      // and as the device sends them — because the fold is order-sensitive.
+      function foldTreeHash(entries) {
+        const h = new Sha256(), enc = new TextEncoder();
+        let totalSize = 0;
         for (let j = 0; j < entries.length; j++) {
-          totalSize += entries[j].size;
+          totalSize += Number(entries[j].size);
           h.update(enc.encode(entries[j].relative_path + '\n' + entries[j].size + '\n' + entries[j].sha256 + '\n'));
         }
-        return { tree_hash: h.hex(), file_count: entries.length, total_size: totalSize, manifest: entries };
+        return { tree_hash: h.hex(), file_count: entries.length, total_size: totalSize };
+      }
+      async function dirManifest(fileList, onProgress) {
+        const picked = [];
+        for (let k = 0; k < fileList.length; k++) {
+          const rel = fileList[k].webkitRelativePath;
+          if (rel) picked.push({ relative_path: stripTopLevel(rel), file: fileList[k] });
+        }
+        return manifestFromFiles(picked, onProgress);
+      }
+
+      // ---- dropped-folder reference (Entries API) ----
+      // A folder dropped onto the page reaches us through webkitGetAsEntry(), which — unlike
+      // showDirectoryPicker() — works on this non-secure http://<LAN-IP> origin, and unlike
+      // <input webkitdirectory> does not make Chrome ask "Upload N files to this site?".
+      // Nothing is uploaded either way; the drop just avoids the misleading prompt.
+      function readAllEntries(reader) {
+        // readEntries() hands back the directory in batches (Chrome: 100 at a time) and
+        // signals the end with an empty array. Calling it once silently truncates the tree
+        // into a wrong tree_hash, so pump it until it drains.
+        return new Promise(function (resolve, reject) {
+          const all = [];
+          (function pump() {
+            reader.readEntries(function (batch) {
+              if (!batch.length) { resolve(all); return; }
+              for (let i = 0; i < batch.length; i++) all.push(batch[i]);
+              pump();
+            }, reject);
+          })();
+        });
+      }
+      function entryToFile(fileEntry) {
+        return new Promise(function (resolve, reject) { fileEntry.file(resolve, reject); });
+      }
+      // Yields the same relative paths as stripTopLevel(webkitRelativePath): '/'-separated and
+      // relative to the dropped folder itself, which the device walk also mirrors.
+      async function walkDirEntry(dirEntry, prefix, depth, out) {
+        if (depth > MAX_VERIFY_DIR_DEPTH) throw new Error('directory nested deeper than ' + MAX_VERIFY_DIR_DEPTH + ' levels');
+        const children = await readAllEntries(dirEntry.createReader());
+        for (let i = 0; i < children.length; i++) {
+          const child = children[i], rel = prefix ? prefix + '/' + child.name : child.name;
+          if (child.isFile) {
+            if (out.length >= MAX_VERIFY_DIR_ENTRIES) throw new Error('more than ' + MAX_VERIFY_DIR_ENTRIES + ' files');
+            out.push({ relative_path: rel, file: await entryToFile(child) });
+          } else if (child.isDirectory) {
+            await walkDirEntry(child, rel, depth + 1, out);
+          }
+        }
+        return out;
+      }
+      async function dirManifestFromDrop(dirEntry, onProgress) {
+        return manifestFromFiles(await walkDirEntry(dirEntry, '', 0, []), onProgress);
       }
 
       // ---- comparison of a device result against the local reference ----
@@ -1573,12 +1670,33 @@
         if (msg.error) return { status: 'error', detail: String(msg.error) };
         if (msg.found === false) return { status: 'notfound', detail: 'path not found' };
         if (msg.tree_hash === verifyDirRef.tree_hash) return { status: 'match', detail: (msg.file_count != null ? msg.file_count + ' files' : '') };
+        // The device reports what is on disk, OS metadata included — content copied over
+        // USB/MTP from a Mac carries `.DS_Store` that a push would have stripped. The
+        // reference never contains those files, so re-fold the device's manifest without
+        // them before calling this a mismatch. Its entries are already in the required sort
+        // order, and dropping some of them preserves it.
+        let deviceEntries = Array.isArray(msg.manifest) ? msg.manifest : null;
+        let ignoredOnDevice = 0;
+        if (deviceEntries) {
+          const kept = deviceEntries.filter(function (e) { return !isOsMetadata(e.relative_path); });
+          ignoredOnDevice = deviceEntries.length - kept.length;
+          if (ignoredOnDevice) {
+            deviceEntries = kept;
+            if (foldTreeHash(kept).tree_hash === verifyDirRef.tree_hash) {
+              return { status: 'match', detail: kept.length + ' files · ' + ignoredOnDevice + ' OS metadata ignored on device' };
+            }
+          }
+        }
         let detail;
-        if (verifyDirRef.manifest && Array.isArray(msg.manifest)) {
-          const d = diffManifests(verifyDirRef.manifest, msg.manifest);
+        if (verifyDirRef.manifest && deviceEntries) {
+          const d = diffManifests(verifyDirRef.manifest, deviceEntries);
           detail = 'missing ' + d.missing.length + ' · added ' + d.added.length + ' · changed ' + d.changed.length;
+          if (ignoredOnDevice) detail += ' (' + ignoredOnDevice + ' OS metadata ignored)';
         } else {
-          detail = 'tree differs (' + (msg.file_count != null ? msg.file_count : '?') + ' files on device vs ' + verifyDirRef.file_count + ' local)';
+          // No manifest (the device omits it above its entry cap), so OS metadata on the
+          // device cannot be discounted — say so rather than let the operator wonder.
+          detail = 'tree differs (' + (msg.file_count != null ? msg.file_count : '?') + ' files on device vs ' + verifyDirRef.file_count + ' local)'
+            + (Array.isArray(msg.manifest) ? '' : '; too large for a per-file diff');
         }
         return { status: 'mismatch', detail: detail };
       }
@@ -1642,17 +1760,47 @@
         renderVerifyResults(verifyApkResults, verifyApkState);
         addLog('Verifying ' + pkg + ' against ' + verifyApkRef.filename + ' on ' + online.length + ' device(s)', 'info');
       }
+      function osMetadataNote(count) { return count ? ' · ' + count + ' OS metadata excluded' : ''; }
+      // Byte-based progress, not file-based: a tree of a few large videos would otherwise sit
+      // on "Hashing 1/13…" long enough to look hung.
+      async function setDirRef(runManifest, source) {
+        verifyDirRefName.textContent = 'Hashing…'; updateButtons();
+        try {
+          const r = await runManifest(function (done, total, doneBytes, totalBytes) {
+            const pct = totalBytes ? Math.floor((doneBytes / totalBytes) * 100) : 100;
+            verifyDirRefName.textContent = 'Hashing ' + pct + '% (' + done + '/' + total + ')…';
+          });
+          verifyDirRef = { tree_hash: r.tree_hash, file_count: r.file_count, total_size: r.total_size, manifest: r.manifest, source: source };
+          verifyDirRefName.textContent = 'Ref: ' + r.file_count + ' files (' + formatBytes(r.total_size) + ')' + osMetadataNote(r.excluded_count);
+          if (r.excluded_count) addLog('Excluded ' + r.excluded_count + ' OS metadata file(s) from the reference (never pushed to devices)', 'info');
+        } catch (e) { verifyDirRefName.textContent = 'Error: ' + e.message; }
+        updateButtons();
+      }
       async function onVerifyDirFolder() {
         verifyDirRef = null; verifyDirJson.value = '';
         const files = verifyDirFolder.files;
         if (!files || !files.length) { verifyDirRefName.textContent = 'No reference'; updateButtons(); return; }
-        verifyDirRefName.textContent = 'Hashing…'; updateButtons();
-        try {
-          const r = await dirManifest(files, function (done, total) { verifyDirRefName.textContent = 'Hashing ' + done + '/' + total + '…'; });
-          verifyDirRef = { tree_hash: r.tree_hash, file_count: r.file_count, total_size: r.total_size, manifest: r.manifest, source: 'folder' };
-          verifyDirRefName.textContent = 'Ref: ' + r.file_count + ' files (' + formatBytes(r.total_size) + ')';
-        } catch (e) { verifyDirRefName.textContent = 'Error: ' + e.message; }
-        updateButtons();
+        await setDirRef(function (onProgress) { return dirManifest(files, onProgress); }, 'folder');
+      }
+      function onVerifyDirDragOver(e) {
+        e.preventDefault(); e.dataTransfer.dropEffect = 'copy';
+        verifyDirDrop.classList.add('over');
+      }
+      function onVerifyDirDragLeave() { verifyDirDrop.classList.remove('over'); }
+      async function onVerifyDirDropped(e) {
+        e.preventDefault(); verifyDirDrop.classList.remove('over');
+        // webkitGetAsEntry() has to run before the first await — DataTransferItems are
+        // emptied as soon as the drop handler yields.
+        const items = e.dataTransfer.items, roots = [];
+        for (let i = 0; i < items.length; i++) {
+          const entry = items[i].webkitGetAsEntry ? items[i].webkitGetAsEntry() : null;
+          if (entry) roots.push(entry);
+        }
+        verifyDirRef = null; verifyDirJson.value = ''; verifyDirFolder.value = '';
+        if (roots.length !== 1 || !roots[0].isDirectory) {
+          verifyDirRefName.textContent = 'Drop exactly one folder'; updateButtons(); return;
+        }
+        await setDirRef(function (onProgress) { return dirManifestFromDrop(roots[0], onProgress); }, 'drop');
       }
       async function onVerifyDirJson() {
         verifyDirRef = null; verifyDirFolder.value = '';
@@ -1662,7 +1810,7 @@
           const obj = JSON.parse(await f.text());
           if (!obj || typeof obj.tree_hash !== 'string') throw new Error('missing tree_hash');
           verifyDirRef = { tree_hash: obj.tree_hash, file_count: obj.file_count, total_size: obj.total_size, manifest: obj.manifest, source: 'json' };
-          verifyDirRefName.textContent = 'Ref (CLI): ' + f.name + (obj.file_count != null ? ' — ' + obj.file_count + ' files' : '');
+          verifyDirRefName.textContent = 'Ref (CLI): ' + f.name + (obj.file_count != null ? ' — ' + obj.file_count + ' files' : '') + osMetadataNote(obj.excluded_count);
         } catch (e) { verifyDirRefName.textContent = 'Invalid hash JSON: ' + e.message; }
         updateButtons();
       }
@@ -1737,6 +1885,12 @@
       verifyApkPkg.addEventListener('input', updateButtons);
       btnVerifyApk.addEventListener('click', sendVerifyApk);
       verifyDirFolder.addEventListener('change', onVerifyDirFolder);
+      verifyDirDrop.addEventListener('dragover', onVerifyDirDragOver);
+      verifyDirDrop.addEventListener('dragleave', onVerifyDirDragLeave);
+      verifyDirDrop.addEventListener('drop', onVerifyDirDropped);
+      // Without this a folder dropped next to the zone would navigate the console away.
+      document.addEventListener('dragover', function (e) { e.preventDefault(); });
+      document.addEventListener('drop', function (e) { e.preventDefault(); });
       verifyDirJson.addEventListener('change', onVerifyDirJson);
       verifyDirPath.addEventListener('input', updateButtons);
       btnVerifyDir.addEventListener('click', sendVerifyDir);

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -496,6 +496,7 @@
       // Integrity verification (issue #37). The reference is computed locally in the
       // browser and never leaves it; only per-device results are compared here.
       let verifyApkRef = null;         // { size, cd_sha256, filename }
+      let verifyApkAutoPkg = '';       // last package name auto-filled from an APK (vs typed)
       let verifyApkState = {};         // id -> { status, detail }
       let verifyDirRef = null;         // { tree_hash, file_count, total_size, manifest?, source }
       let verifyDirState = {};         // id -> { status, detail }
@@ -1356,6 +1357,7 @@
       };
 
       const EOCD_MIN = 22, MAX_COMMENT = 0xffff, ZIP64_SENTINEL = 0xffffffff, HASH_CHUNK = 4 * 1024 * 1024;
+      const CD_SIG = 0x02014b50, LFH_SIG = 0x04034b50, STORED = 0, DEFLATED = 8;
       function findEocd(tail, fileLen, tailStart, view) {
         for (let i = tail.length - EOCD_MIN; i >= 0; i--) {
           if (tail[i] === 0x50 && tail[i + 1] === 0x4b && tail[i + 2] === 0x05 && tail[i + 3] === 0x06) {
@@ -1365,23 +1367,147 @@
         }
         throw new Error('End Of Central Directory record not found (not a valid ZIP/APK?)');
       }
-      // size + SHA-256 of the ZIP Central-Directory region [CD_offset .. EOF]. Reads only
-      // the tail + CD region, so a 1 GB+ APK is not loaded into memory and nothing uploads.
-      async function apkCdDigest(file) {
+      async function zipCentralDirectory(file) {
         const size = file.size;
         const readLen = Math.min(size, EOCD_MIN + MAX_COMMENT);
         const tailStart = size - readLen;
         const tailBuf = new Uint8Array(await file.slice(tailStart, size).arrayBuffer());
         const view = new DataView(tailBuf.buffer, tailBuf.byteOffset, tailBuf.byteLength);
         const eocdOff = findEocd(tailBuf, size, tailStart, view);
+        const cdSize = view.getUint32(eocdOff + 12, true);
         const cdOffset = view.getUint32(eocdOff + 16, true);
-        if (cdOffset === ZIP64_SENTINEL) throw new Error('zip64 archives are not supported');
-        const h = new Sha256();
-        for (let pos = cdOffset; pos < size; pos += HASH_CHUNK) {
-          h.update(new Uint8Array(await file.slice(pos, Math.min(pos + HASH_CHUNK, size)).arrayBuffer()));
-        }
-        return { size: size, cd_sha256: h.hex() };
+        if (cdOffset === ZIP64_SENTINEL || cdSize === ZIP64_SENTINEL) throw new Error('zip64 archives are not supported');
+        return { size: size, cdOffset: cdOffset, cdSize: cdSize };
       }
+      // size + SHA-256 of the ZIP Central-Directory region [CD_offset .. EOF]. Reads only
+      // the tail + CD region, so a 1 GB+ APK is not loaded into memory and nothing uploads.
+      async function apkCdDigest(file) {
+        const cd = await zipCentralDirectory(file);
+        const h = new Sha256();
+        for (let pos = cd.cdOffset; pos < cd.size; pos += HASH_CHUNK) {
+          h.update(new Uint8Array(await file.slice(pos, Math.min(pos + HASH_CHUNK, cd.size)).arrayBuffer()));
+        }
+        return { size: cd.size, cd_sha256: h.hex() };
+      }
+
+      // ---- APK -> package name, read in the browser (nothing is uploaded) ----
+      // Reads AndroidManifest.xml out of the picked APK and parses the binary XML, so the
+      // operator does not have to retype a package name that is already in the file.
+      const MANIFEST_NAME = 'AndroidManifest.xml', MAX_MANIFEST_BYTES = 8 * 1024 * 1024;
+      function bytesEqual(buf, off, want) {
+        for (let i = 0; i < want.length; i++) { if (buf[off + i] !== want[i]) return false; }
+        return true;
+      }
+      async function inflateRaw(bytes) {
+        if (typeof DecompressionStream !== 'function') throw new Error('this browser cannot inflate deflate-raw');
+        const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+        return new Uint8Array(await new Response(stream).arrayBuffer());
+      }
+      // Walk the Central Directory for one entry and return its uncompressed bytes.
+      async function zipEntryBytes(file, wantName) {
+        const cd = await zipCentralDirectory(file);
+        const cdBuf = new Uint8Array(await file.slice(cd.cdOffset, cd.cdOffset + cd.cdSize).arrayBuffer());
+        const cv = new DataView(cdBuf.buffer, cdBuf.byteOffset, cdBuf.byteLength);
+        const want = utf8Bytes(wantName);
+        let p = 0;
+        while (p + 46 <= cdBuf.length && cv.getUint32(p, true) === CD_SIG) {
+          const method = cv.getUint16(p + 10, true);
+          const compSize = cv.getUint32(p + 20, true);
+          const nameLen = cv.getUint16(p + 28, true);
+          const extraLen = cv.getUint16(p + 30, true);
+          const commentLen = cv.getUint16(p + 32, true);
+          const lfhOffset = cv.getUint32(p + 42, true);
+          if (nameLen === want.length && bytesEqual(cdBuf, p + 46, want)) {
+            if (compSize === ZIP64_SENTINEL || lfhOffset === ZIP64_SENTINEL) throw new Error('zip64 archives are not supported');
+            if (compSize > MAX_MANIFEST_BYTES) throw new Error(wantName + ' is implausibly large');
+            const lfh = new DataView(await file.slice(lfhOffset, lfhOffset + 30).arrayBuffer());
+            if (lfh.byteLength < 30 || lfh.getUint32(0, true) !== LFH_SIG) throw new Error('bad local file header for ' + wantName);
+            // The local header carries its own extra field (zipalign padding), unrelated in
+            // length to the Central Directory's, so the data offset must come from here.
+            const dataStart = lfhOffset + 30 + lfh.getUint16(26, true) + lfh.getUint16(28, true);
+            const raw = new Uint8Array(await file.slice(dataStart, dataStart + compSize).arrayBuffer());
+            if (method === STORED) return raw;
+            if (method === DEFLATED) return inflateRaw(raw);
+            throw new Error('unsupported compression method ' + method + ' for ' + wantName);
+          }
+          p += 46 + nameLen + extraLen + commentLen;
+        }
+        return null;
+      }
+
+      const AXML_MAGIC = 0x0003, RES_STRING_POOL = 0x0001, RES_XML_START_ELEMENT = 0x0102;
+      const UTF8_FLAG = 1 << 8, TYPE_STRING = 0x03;
+      // Strings are UTF-8 or UTF-16LE depending on UTF8_FLAG; both occur in real APKs.
+      function axmlStringPool(bytes, view, off) {
+        const headerSize = view.getUint16(off + 2, true);
+        const stringCount = view.getUint32(off + 8, true);
+        const flags = view.getUint32(off + 16, true);
+        const stringsStart = view.getUint32(off + 20, true);
+        const utf8 = (flags & UTF8_FLAG) !== 0;
+        const dec = new TextDecoder(utf8 ? 'utf-8' : 'utf-16le');
+        const base = off + stringsStart;
+        return function (idx) {
+          if (idx < 0 || idx >= stringCount) return null;
+          let p = base + view.getUint32(off + headerSize + idx * 4, true);
+          if (utf8) {
+            // Two varint-ish lengths (character count, then byte count); a set high bit
+            // means the length spills into a second byte.
+            if (bytes[p++] & 0x80) p++;
+            let nbytes = bytes[p++];
+            if (nbytes & 0x80) nbytes = ((nbytes & 0x7f) << 8) | bytes[p++];
+            return dec.decode(bytes.subarray(p, p + nbytes));
+          }
+          let nchars = view.getUint16(p, true); p += 2;
+          if (nchars & 0x8000) { nchars = ((nchars & 0x7fff) << 16) | view.getUint16(p, true); p += 2; }
+          return dec.decode(bytes.subarray(p, p + nchars * 2));
+        };
+      }
+      // Returns the attributes of the root <manifest> element that identify the build.
+      function parseAndroidManifest(bytes) {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        if (bytes.length < 8 || view.getUint16(0, true) !== AXML_MAGIC) throw new Error('not a binary AndroidManifest.xml');
+        const end = Math.min(view.getUint32(4, true), bytes.length);
+        let str = null;
+        let off = view.getUint16(2, true);
+        while (off + 8 <= end) {
+          const type = view.getUint16(off, true);
+          const chunkSize = view.getUint32(off + 4, true);
+          if (chunkSize < 8 || off + chunkSize > end) break;
+          if (type === RES_STRING_POOL) {
+            str = axmlStringPool(bytes, view, off);
+          } else if (type === RES_XML_START_ELEMENT) {
+            if (!str) throw new Error('AndroidManifest.xml has no string pool');
+            // ResXMLTree_node is 16 bytes; the attribute extension follows it.
+            const ext = off + 16;
+            if (str(view.getUint32(ext + 4, true)) === 'manifest') {
+              const attrStart = view.getUint16(ext + 8, true);
+              const attrSize = view.getUint16(ext + 10, true);
+              const attrCount = view.getUint16(ext + 12, true);
+              const out = {};
+              for (let i = 0; i < attrCount; i++) {
+                const a = ext + attrStart + i * attrSize;
+                if (a + 20 > end) break;
+                const name = str(view.getUint32(a + 4, true));
+                const rawValue = view.getInt32(a + 8, true);
+                const dataType = view.getUint8(a + 15);
+                const data = view.getUint32(a + 16, true);
+                const asString = rawValue >= 0 ? str(rawValue) : (dataType === TYPE_STRING ? str(data) : null);
+                if (name === 'package') out.package = asString;
+                else if (name === 'versionName') out.versionName = asString;
+              }
+              return out;
+            }
+          }
+          off += chunkSize;
+        }
+        throw new Error('<manifest> element not found');
+      }
+      async function apkManifestInfo(file) {
+        const bytes = await zipEntryBytes(file, MANIFEST_NAME);
+        if (!bytes) throw new Error(MANIFEST_NAME + ' not found (not an APK?)');
+        return parseAndroidManifest(bytes);
+      }
+
       async function fileSha256(file) {
         const h = new Sha256();
         for (let pos = 0; pos < file.size; pos += HASH_CHUNK) {
@@ -1475,16 +1601,34 @@
       }
 
       // ---- reference selection + command dispatch ----
+      // Carrying a package name over from a previously picked APK would silently verify the
+      // new reference against the old package, so drop what we filled in ourselves. A name
+      // the operator typed is theirs and survives.
+      function setAutoPkg(pkg) {
+        if (pkg || verifyApkPkg.value === verifyApkAutoPkg) verifyApkPkg.value = pkg;
+        verifyApkAutoPkg = pkg;
+      }
       async function onVerifyApkFile() {
         verifyApkRef = null;
         const f = verifyApkFile.files[0];
-        if (!f) { verifyApkName.textContent = 'No reference APK'; updateButtons(); return; }
+        if (!f) { verifyApkName.textContent = 'No reference APK'; setAutoPkg(''); updateButtons(); return; }
         verifyApkName.textContent = 'Hashing ' + f.name + '…'; updateButtons();
         try {
           const r = await apkCdDigest(f);
           verifyApkRef = { size: r.size, cd_sha256: r.cd_sha256, filename: f.name };
           verifyApkName.textContent = 'Ref: ' + f.name + ' (' + formatBytes(r.size) + ')';
-        } catch (e) { verifyApkName.textContent = 'Error: ' + e.message; }
+        } catch (e) { verifyApkName.textContent = 'Error: ' + e.message; setAutoPkg(''); updateButtons(); return; }
+        // Best effort: fill in the package name from the APK itself. The field stays
+        // editable, and any failure leaves the operator with plain manual entry.
+        try {
+          const info = await apkManifestInfo(f);
+          if (!info.package) throw new Error('no package attribute on <manifest>');
+          setAutoPkg(info.package);
+          verifyApkName.textContent += info.versionName ? ' · v' + info.versionName : '';
+        } catch (e) {
+          setAutoPkg('');
+          addLog('Could not read the package name from ' + f.name + ', enter it manually (' + e.message + ')', 'warn');
+        }
         updateButtons();
       }
       function sendVerifyApk() {

--- a/mdm-server/tests/test_integrity.py
+++ b/mdm-server/tests/test_integrity.py
@@ -1,0 +1,169 @@
+"""Tests for the integrity helpers (issue #37).
+
+These pin the canonical hashing spec that the browser (pure JS) and device (Kotlin)
+implementations must reproduce byte-for-byte, so a change here that would break
+cross-implementation agreement fails a test rather than silently reporting every
+device as a mismatch.
+"""
+
+import hashlib
+import os
+import struct
+import zipfile
+
+import pytest
+
+from styly_mdm import integrity
+
+
+# --------------------------------------------------------------------------- #
+# APK / ZIP Central-Directory digest
+# --------------------------------------------------------------------------- #
+
+def _make_zip(path, entries, comment=b""):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+        if comment:
+            zf.comment = comment
+
+
+def _independent_cd_digest(path):
+    """Re-derive size + CD digest without using integrity.py, to catch a spec drift."""
+    file_len = os.path.getsize(path)
+    with open(path, "rb") as f:
+        blob = f.read()
+    # No ZIP64, comment length known from EOCD; scan for the last EOCD.
+    for i in range(len(blob) - 22, -1, -1):
+        if blob[i:i + 4] == b"\x50\x4b\x05\x06":
+            comment_len = struct.unpack_from("<H", blob, i + 20)[0]
+            if i + 22 + comment_len == file_len:
+                cd_off = struct.unpack_from("<I", blob, i + 16)[0]
+                return file_len, hashlib.sha256(blob[cd_off:]).hexdigest()
+    raise AssertionError("no EOCD in test fixture")
+
+
+def test_apk_cd_digest_matches_independent(tmp_path):
+    apk = tmp_path / "a.apk"
+    _make_zip(apk, {"AndroidManifest.xml": b"x" * 100, "classes.dex": b"y" * 500})
+    size, cd = integrity.apk_cd_digest(str(apk))
+    exp_size, exp_cd = _independent_cd_digest(str(apk))
+    assert (size, cd) == (exp_size, exp_cd)
+    assert len(cd) == 64
+
+
+def test_apk_cd_digest_is_deterministic(tmp_path):
+    apk = tmp_path / "a.apk"
+    _make_zip(apk, {"a": b"a", "b": b"b"})
+    assert integrity.apk_cd_digest(str(apk)) == integrity.apk_cd_digest(str(apk))
+
+
+def test_apk_cd_digest_changes_when_contents_change(tmp_path):
+    a, b = tmp_path / "a.apk", tmp_path / "b.apk"
+    _make_zip(a, {"f": b"hello"})
+    _make_zip(b, {"f": b"hello!"})  # different size/CRC perturbs the Central Directory
+    assert integrity.apk_cd_digest(str(a))[1] != integrity.apk_cd_digest(str(b))[1]
+
+
+def test_apk_cd_digest_handles_zip_comment(tmp_path):
+    """A non-empty EOCD comment must not defeat the EOCD scan."""
+    apk = tmp_path / "c.apk"
+    _make_zip(apk, {"f": b"data"}, comment=b"this is a trailing comment PK\x05\x06 lookalike")
+    size, cd = integrity.apk_cd_digest(str(apk))
+    assert (size, cd) == _independent_cd_digest(str(apk))
+
+
+def test_apk_cd_digest_rejects_zip64_sentinel(tmp_path):
+    apk = tmp_path / "z.apk"
+    _make_zip(apk, {"f": b"data"})
+    blob = bytearray(apk.read_bytes())
+    # Find the EOCD (no comment) and force the CD-offset field to the ZIP64 sentinel.
+    idx = blob.rfind(b"\x50\x4b\x05\x06")
+    struct.pack_into("<I", blob, idx + 16, 0xFFFFFFFF)
+    apk.write_bytes(blob)
+    with pytest.raises(integrity.Zip64UnsupportedError):
+        integrity.apk_cd_digest(str(apk))
+
+
+def test_apk_cd_digest_rejects_non_zip(tmp_path):
+    f = tmp_path / "not.apk"
+    f.write_bytes(b"definitely not a zip archive")
+    with pytest.raises(ValueError):
+        integrity.apk_cd_digest(str(f))
+
+
+# --------------------------------------------------------------------------- #
+# Directory manifest + tree hash
+# --------------------------------------------------------------------------- #
+
+def _write(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _expected_tree_hash(files):
+    """Independent tree-hash of {relative_path: bytes}, matching the documented spec."""
+    entries = sorted(files.items(), key=lambda kv: kv[0].encode("utf-8"))
+    h = hashlib.sha256()
+    for rel, data in entries:
+        line = "{}\n{}\n{}\n".format(rel, len(data), hashlib.sha256(data).hexdigest())
+        h.update(line.encode("utf-8"))
+    return h.hexdigest()
+
+
+def test_dir_manifest_matches_independent_spec(tmp_path):
+    files = {
+        "a.txt": b"hello world\n",
+        "sub/b.bin": b"nested content",
+        "sub/deep/c.dat": b"deeper",
+        "sub/deep/empty-file": b"",
+        "zsub/z.txt": b"z",
+        "日本語.txt": b"unicode name content",  # non-ASCII sorts by UTF-8 bytes
+    }
+    for rel, data in files.items():
+        _write(tmp_path / rel, data)
+    (tmp_path / "emptydir").mkdir()  # empty dir must not appear in the manifest
+
+    result = integrity.dir_manifest(str(tmp_path))
+    assert result["tree_hash"] == _expected_tree_hash(files)
+    assert result["file_count"] == len(files)
+    assert result["total_size"] == sum(len(d) for d in files.values())
+    paths = [e["relative_path"] for e in result["manifest"]]
+    assert paths == sorted(files.keys(), key=lambda p: p.encode("utf-8"))
+    assert all("/" in p or "\\" not in p for p in paths)  # forward slashes only
+
+
+def test_dir_manifest_is_deterministic(tmp_path):
+    _write(tmp_path / "x", b"1")
+    _write(tmp_path / "y", b"2")
+    assert integrity.dir_manifest(str(tmp_path)) == integrity.dir_manifest(str(tmp_path))
+
+
+def test_dir_manifest_skips_symlinks(tmp_path):
+    _write(tmp_path / "real.txt", b"data")
+    try:
+        os.symlink(tmp_path / "real.txt", tmp_path / "link.txt")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    result = integrity.dir_manifest(str(tmp_path))
+    assert [e["relative_path"] for e in result["manifest"]] == ["real.txt"]
+
+
+def test_dir_manifest_omits_manifest_above_cap(tmp_path):
+    for i in range(5):
+        _write(tmp_path / f"f{i}", b"x")
+    capped = integrity.dir_manifest(str(tmp_path), manifest_entry_cap=3)
+    assert "manifest" not in capped
+    assert capped["file_count"] == 5
+    assert capped["tree_hash"]  # tree hash still distinguishes same/different
+    uncapped = integrity.dir_manifest(str(tmp_path), manifest_entry_cap=10)
+    assert "manifest" in uncapped
+    assert capped["tree_hash"] == uncapped["tree_hash"]
+
+
+def test_dir_manifest_empty_tree(tmp_path):
+    result = integrity.dir_manifest(str(tmp_path))
+    assert result["file_count"] == 0
+    assert result["total_size"] == 0
+    assert result["manifest"] == []
+    assert result["tree_hash"] == hashlib.sha256(b"").hexdigest()

--- a/mdm-server/tests/test_integrity.py
+++ b/mdm-server/tests/test_integrity.py
@@ -161,6 +161,50 @@ def test_dir_manifest_omits_manifest_above_cap(tmp_path):
     assert capped["tree_hash"] == uncapped["tree_hash"]
 
 
+def test_dir_manifest_excludes_os_metadata(tmp_path):
+    _write(tmp_path / "Movies" / "clip.mp4", b"movie")
+    _write(tmp_path / ".DS_Store", b"junk")
+    _write(tmp_path / "Movies" / ".DS_Store", b"junk")
+    _write(tmp_path / "Movies" / "._clip.mp4", b"junk")
+    _write(tmp_path / "__MACOSX" / "._clip.mp4", b"junk")
+    result = integrity.dir_manifest(str(tmp_path))
+    assert [e["relative_path"] for e in result["manifest"]] == ["Movies/clip.mp4"]
+    assert result["excluded_count"] == 4
+
+
+def test_dir_manifest_keeps_authored_dotfiles(tmp_path):
+    # The exclusion list is deliberately narrow: anything a user could have written stays.
+    _write(tmp_path / ".gitignore", b"x")
+    _write(tmp_path / "scene.unity.meta", b"x")
+    _write(tmp_path / ".git" / "config", b"x")
+    result = integrity.dir_manifest(str(tmp_path))
+    assert [e["relative_path"] for e in result["manifest"]] == [
+        ".git/config", ".gitignore", "scene.unity.meta"]
+    assert result["excluded_count"] == 0
+
+
+def test_reference_matches_the_tree_that_push_delivers(tmp_path):
+    """A folder picked as a reference must hash to what `push files` actually ships.
+
+    `upload_bundle_handler` drops OS metadata on the way into the bundle, so a device never
+    receives it. If the reference kept those files the console would report a permanent
+    `missing N` against a device that is in fact identical.
+    """
+    source, delivered = tmp_path / "source", tmp_path / "delivered"
+    for rel in ["Movies/clip.mp4", "Textures/a.png"]:
+        _write(source / rel, rel.encode())
+        _write(delivered / rel, rel.encode())          # what survives the bundle
+    for junk in [".DS_Store", "Movies/.DS_Store", "Movies/._clip.mp4"]:
+        _write(source / junk, b"junk")                 # stripped by the bundle upload
+        assert integrity.is_os_metadata(junk) is True
+
+    reference = integrity.dir_manifest(str(source))
+    device = integrity.dir_manifest(str(delivered))
+    assert reference["tree_hash"] == device["tree_hash"]
+    assert reference["file_count"] == device["file_count"] == 2
+    assert reference["excluded_count"] == 3
+
+
 def test_dir_manifest_empty_tree(tmp_path):
     result = integrity.dir_manifest(str(tmp_path))
     assert result["file_count"] == 0

--- a/mdm-server/tests/test_push_files.py
+++ b/mdm-server/tests/test_push_files.py
@@ -14,7 +14,7 @@ from aiohttp.test_utils import TestClient, TestServer
 import pytest
 
 import styly_mdm
-from styly_mdm import server
+from styly_mdm import integrity, server
 
 
 # ---------------------------------------------------------------------------
@@ -170,8 +170,8 @@ def test_strip_common_root():
     "$RECYCLE.BIN/a",
     ".Trash-1000/files/a",                 # Linux per-user trash on removable media
 ])
-def test_is_excluded_bundle_entry_matches_os_metadata(relpath):
-    assert server.is_excluded_bundle_entry(relpath) is True
+def test_is_os_metadata_matches_os_metadata(relpath):
+    assert integrity.is_os_metadata(relpath) is True
 
 
 @pytest.mark.parametrize("relpath", [
@@ -184,8 +184,8 @@ def test_is_excluded_bundle_entry_matches_os_metadata(relpath):
     "my.DS_Store.txt",                     # substring, not the whole segment
     "desktop.ini.bak",
 ])
-def test_is_excluded_bundle_entry_keeps_real_content(relpath):
-    assert server.is_excluded_bundle_entry(relpath) is False
+def test_is_os_metadata_keeps_real_content(relpath):
+    assert integrity.is_os_metadata(relpath) is False
 
 
 def test_upload_bundle_drops_os_metadata_and_reports_the_count(tmp_path):

--- a/mdm-server/tests/test_verify_routing.py
+++ b/mdm-server/tests/test_verify_routing.py
@@ -1,0 +1,119 @@
+"""Routing tests for the integrity-verification messages (issue #37).
+
+No network: the async handlers are driven directly with fake WebSocket stubs that
+record what they were sent, mirroring how the server relays INSTALL_APK.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from styly_mdm import server
+
+
+class FakeWS:
+    """Minimal stand-in for aiohttp's WebSocketResponse (records sent frames)."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send_str(self, s):
+        self.sent.append(json.loads(s))
+
+
+@pytest.fixture(autouse=True)
+def clean_devices():
+    saved = dict(server.devices)
+    server.devices.clear()
+    yield
+    server.devices.clear()
+    server.devices.update(saved)
+
+
+def _add_device(device_id):
+    ws = FakeWS()
+    server.devices[device_id] = {"ws": ws, "device_id": device_id}
+    return ws
+
+
+# --------------------------------------------------------------------------- #
+# VERIFY_APK
+# --------------------------------------------------------------------------- #
+
+def test_verify_apk_fans_out_and_acks():
+    dev = _add_device("DEV1")
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_apk(admin, {"target_devices": ["DEV1"], "package_name": "com.x"}))
+    assert dev.sent == [{"type": "EXECUTE_VERIFY_APK", "package_name": "com.x"}]
+    ack = admin.sent[-1]
+    assert ack["type"] == "VERIFY_SENT"
+    assert ack["package_name"] == "com.x"
+    assert ack["sent_count"] == 1
+    assert ack["target_count"] == 1
+
+
+def test_verify_apk_wildcard_targets_all_online():
+    d1, d2 = _add_device("A"), _add_device("B")
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_apk(admin, {"target_devices": ["*"], "package_name": "com.x"}))
+    assert len(d1.sent) == 1 and len(d2.sent) == 1
+    assert admin.sent[-1]["sent_count"] == 2
+
+
+def test_verify_apk_requires_package_name():
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_apk(admin, {"target_devices": ["DEV1"]}))
+    assert admin.sent[-1] == {"type": "ERROR", "message": "package_name is required"}
+
+
+def test_verify_apk_no_matching_devices():
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_apk(admin, {"target_devices": ["GHOST"], "package_name": "com.x"}))
+    assert admin.sent[-1]["type"] == "ERROR"
+    assert "online" in admin.sent[-1]["message"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# VERIFY_DIR
+# --------------------------------------------------------------------------- #
+
+def test_verify_dir_fans_out_and_acks():
+    dev = _add_device("DEV1")
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_dir(admin, {"target_devices": ["DEV1"], "path": "/sdcard/content"}))
+    assert dev.sent == [{"type": "EXECUTE_VERIFY_DIR", "path": "/sdcard/content"}]
+    ack = admin.sent[-1]
+    assert ack["type"] == "VERIFY_DIR_SENT"
+    assert ack["path"] == "/sdcard/content"
+    assert ack["sent_count"] == 1
+
+
+@pytest.mark.parametrize("bad_path", ["", "relative/path", "/sdcard/../data/x", ".."])
+def test_verify_dir_rejects_unsafe_path(bad_path):
+    _add_device("DEV1")
+    admin = FakeWS()
+    asyncio.run(server.handle_verify_dir(admin, {"target_devices": ["DEV1"], "path": bad_path}))
+    assert admin.sent[-1]["type"] == "ERROR"
+
+
+@pytest.mark.parametrize("good_path", ["/sdcard", "/sdcard/content", "/storage/emulated/0/x/y"])
+def test_is_syntactically_safe_verify_path_accepts(good_path):
+    assert server.is_syntactically_safe_verify_path(good_path)
+
+
+@pytest.mark.parametrize("bad_path", ["", "rel", "/a/../b", "/a/..", "..", "/.."])
+def test_is_syntactically_safe_verify_path_rejects(bad_path):
+    assert not server.is_syntactically_safe_verify_path(bad_path)
+
+
+# --------------------------------------------------------------------------- #
+# device-result routing (the forward set must relay both result types)
+# --------------------------------------------------------------------------- #
+
+def test_result_message_types_are_forwarded():
+    """The device handler forwards these verbatim to admins after stamping device_id."""
+    import inspect
+    src = inspect.getsource(server.device_ws_handler)
+    assert "VERIFY_APK_RESULT" in src
+    assert "VERIFY_DIR_RESULT" in src


### PR DESCRIPTION
Closes #37.

On-demand check that a package or a directory on a managed device still matches a reference the operator holds locally.

## Design

The **reference is computed and the comparison happens client-side** — in the browser, or with the new `styly-mdm hash` CLI. The server only relays `VERIFY_*` messages; it never hashes. Two hard constraints fall out of this:

- A 1 GB+ APK is **never uploaded** just to be checked. The browser reads only the ZIP central directory (located via the EOCD record) and compares `size` + `cd_sha256` against what the device reports for `sourceDir`.
- **No HTTPS / secure context is required.** The console is served over plain `http://<LAN-IP>`, where `crypto.subtle` is unavailable, so SHA-256 is a pure-JS implementation, byte-for-byte identical to the Python and Kotlin ones.

Directories use a manifest + tree hash: `{relative_path, size, sha256}` per regular file, sorted by the UTF-8 byte order of `relative_path`, folded into one `tree_hash`. When both manifests are present the console diffs them into missing / added / changed.

## Reference input, and why a drop zone

A reference folder can be **dropped** onto the Verify Directory drop zone, or chosen with *Choose Folder*. Both produce the same manifest. The drop zone exists because Chrome shows an alarming — and, here, untrue — `Upload N files to this site?` confirmation for any `<input webkitdirectory>` pick. A drop arrives via `DataTransferItem.webkitGetAsEntry()`, which raises no such prompt and, unlike `showDirectoryPicker()`, works on a non-secure origin.

Two traps in that path, both of which produce a *wrong* `tree_hash` rather than an error:

- `DirectoryReader.readEntries()` returns the directory in batches (100 at a time in Chrome) and must be pumped until it yields an empty array. A single call silently truncates the tree.
- `webkitGetAsEntry()` must run before the handler's first `await`, because `DataTransferItem`s are emptied as soon as it yields.

## OS metadata is not content

`POST /api/bundles` already stripped `.DS_Store`, AppleDouble `._*` sidecars, `Thumbs.db`, `__MACOSX/` and friends on the way into a push bundle, so a device never receives them. The verify reference did not, which meant **any macOS reference folder reported a permanent `missing N` against a device that was byte-identical**.

The rule now lives once, in `integrity.is_os_metadata()`, imported by `server.py` and mirrored as `isOsMetadata()` in the console, and the **reference builders** apply it: a reference must describe what push actually delivers. The list stays deliberately narrow — `.git/`, Unity `.meta` and dotfiles at large are content, and silently dropping content is worse than keeping a stray `.DS_Store`. Exclusions are counted and shown (`excluded_count`), never silent.

Content can also reach a device by other routes (USB/MTP from a Mac), and then the device really does hold `.DS_Store`. `classifyDir()` therefore re-folds the device's manifest without those entries before declaring a mismatch — the manifest arrives already sorted, and dropping entries preserves the order — so the **device-side walk needs no change**. Above the device's manifest entry cap no manifest is sent and the metadata cannot be discounted; the console says so rather than blaming the operator's tree.

So the invariant is *not* "all three implementations hash any input identically". It is: **the reference builders agree with each other and model what push delivers, while the device reports ground truth.**

## Reporting

Verdicts appear in the same per-device **PROGRESS column** as install and push (`⟳ Verifying…` → `✓ match` / `✗ mismatch` / `✗ not found` / `✗ error`), so the mismatching headset is identified in its own row. The column is far too narrow for `missing 3 · added 0 · changed 1`, so the detail rides in the cell's `title` and in the log, which keeps every verdict even after a later job overwrites the cell. `installState` has held pushes since #41 and now verifies too, so it is `deviceTaskState`.

## Client

`QUERY_ALL_PACKAGES` is added so `PackageManager` can resolve an arbitrary installed package on API 30+; `MANAGE_EXTERNAL_STORAGE` gates the directory walk, which is canonicalized and bounded to shared external storage. Symlinks are skipped and never followed.

## Verification

- `styly-mdm hash`, the `webkitdirectory` picker, and the drop path produce an identical `tree_hash` on a 258-file tree — including a directory of 251 files that crosses three `readEntries()` batches, unicode and spaced names, and OS junk. Breaking the pump loop drops it to 104 files and a different hash, so the check bites.
- JS `isOsMetadata` matches Python `is_os_metadata` across 28 names, including the content that must survive (`.gitignore`, `.git/config`, `scene.unity.meta`).
- Device-side junk classifies as `match … N OS metadata ignored on device`, while a missing or changed content file still classifies as `mismatch` — the filter reconciles junk without masking real drift.
- 143 server tests pass.
- The drag-drop flow, the absence of the Upload prompt, and the PROGRESS column were confirmed by hand in Chrome against the real `http://<LAN-IP>` origin (a synthetic `DataTransfer` cannot carry real `FileSystemEntry` objects, so this part is not automatable).

## Also

Fixes `esc()`: `textContent` → `innerHTML` escapes `&` `<` `>` but leaves quotes, and eleven of its twelve call sites interpolate into an attribute. A device- or server-supplied string containing a double quote escaped the attribute it was meant to fill. Pre-existing; found while checking the new `title=` tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)