### PR TITLE
feat: surface server and mdm-client versions (#42)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -161,7 +161,7 @@ STYLY-MDM/
             ├── MdmClientApplication.kt   # Application entry point
             ├── MdmClientService.kt       # Foreground service; executes launch commands
             ├── WebSocketManager.kt       # WebSocket connection with auto-reconnect
-            ├── SettingsActivity.kt       # UI to configure server URL; Update Journal viewer
+            ├── SettingsActivity.kt       # UI to configure server URL; shows client build; Update Journal viewer
             ├── ServerDiscovery.kt        # UDP broadcast server discovery
             ├── BundleSync.kt             # Push/sync a file bundle into a device directory
             ├── UpdateJournal.kt          # Persistent event log; survives a self-update kill
@@ -227,7 +227,7 @@ STYLY-MDM/
 
 | Message type | Description |
 |---|---|
-| `DEVICE_LIST` | Current list of known devices. Fields: `devices` (array; each entry carries `status` (`online` / `offline` / `updating` — the latter while a self-update's power cycle is in flight), `version_code` / `version_name` (the client build, when known), and may include optional `battery`: `{level, charging, last_seen}`) |
+| `DEVICE_LIST` | Current list of known devices. Fields: `devices` (array; each entry carries `status` (`online` / `offline` / `updating` — the latter while a self-update's power cycle is in flight), `version_code` / `version_name` (the client build, when known — the console renders it as a right-aligned badge per row, or `unknown` for clients that predate version reporting), and may include optional `battery`: `{level, charging, last_seen}`) |
 | `LAUNCH_SENT` | Confirmation that commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
 | `INSTALL_SENT` | Confirmation that an install job was accepted (dispatch is throttled and runs in the background). Fields: `apk_filename`, `apk_url`, `target_count`, `max_concurrent` |
 | `INSTALL_PROGRESS` | Live progress of a throttled install job, broadcast on each transfer-slot transition. Fields: `apk_filename`, `apk_url`, `total`, `queued`, `transferring`, `transferred`, `failed`, `done` (boolean, `true` on the final update) |

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
@@ -50,6 +50,10 @@ class SettingsActivity : AppCompatActivity() {
         // started below, so the journal shows which route brought the client back.
         UpdateJournal.record(this, UpdateJournal.EVENT_ACTIVITY_ONCREATE)
 
+        // Surface the installed build on the settings screen (VERSION_NAME already carries
+        // the "-dev" suffix for the dev flavor, so no special-casing is needed here).
+        findViewById<TextView>(R.id.app_version).text = "v${BuildConfig.VERSION_NAME}"
+
         serverUrlInput = findViewById(R.id.server_url_input)
         statusText = findViewById(R.id.status_text)
         saveButton = findViewById(R.id.save_button)

--- a/mdm-client/app/src/main/res/layout/activity_settings.xml
+++ b/mdm-client/app/src/main/res/layout/activity_settings.xml
@@ -14,13 +14,31 @@
         android:padding="24dp"
         android:gravity="center_horizontal">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <!-- Title bar: app name on the left, installed build right-aligned. The version is
+             filled in at runtime from BuildConfig so an operator holding the headset can
+             read the build without ADB. -->
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/app_name"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="32dp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="32dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/app_name"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/app_version"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:textColor="?android:attr/textColorSecondary" />
+        </LinearLayout>
 
         <TextView
             android:layout_width="match_parent"

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -2586,7 +2586,13 @@ async def run_server(port: int | None = None):
     app = create_app()
     ip_addresses = get_local_ip_addresses()
 
-    log.info("Starting STYLY-MDM server on port %d", port)
+    # Imported lazily to avoid a circular import: __init__ defines __version__ but
+    # also imports this module. setuptools_scm reports "0.0.0" from a checkout with
+    # no tags (or an install outside a git tree); label that so the log never reads
+    # like a real release.
+    from . import __version__
+    version_label = f"{__version__} (untagged)" if __version__ == "0.0.0" else __version__
+    log.info("Starting STYLY-MDM server v%s on port %d", version_label, port)
     if ip_addresses:
         for ip in ip_addresses:
             log.info("  Server running at http://%s:%d", ip, port)

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -152,6 +152,10 @@
     .dev-label-row { display: flex; align-items: center; gap: 6px; }
     .dev-label { font-weight: 600; font-size: 14px; }
     .dev-label.unlabeled { color: var(--text-secondary); font-weight: 400; }
+    /* Client build, pulled out of the grey sub-line and right-aligned so laggards are
+       scannable down the list after a rollout. Muted + "unknown" for pre-version clients. */
+    .dev-version { margin-left: auto; flex: 0 0 auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; font-weight: 600; color: var(--text-secondary); background: var(--bg-actions); border: 1px solid var(--border-soft); border-radius: 4px; padding: 1px 6px; white-space: nowrap; }
+    .dev-version.unknown { color: var(--text-muted); font-weight: 400; }
     .dev-sub { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--text-muted); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .dev-status { font-size: 13px; }
     .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--success); margin-right: 6px; vertical-align: middle; }
@@ -832,15 +836,19 @@
               '<button class="btn-mini btn-save" data-act="saveLabel" data-id="' + esc(id) + '">Save</button>' +
               '<button class="btn-mini btn-cancel" data-act="cancelLabel">Cancel</button></div>';
           } else {
+            // Client build, right-aligned in the label row so it reads as a column across
+            // rows; older clients that predate the version field show a muted "unknown".
+            const verBadge = d.version_name
+              ? '<span class="dev-version" title="Client build">v' + esc(d.version_name) + '</span>'
+              : '<span class="dev-version unknown" title="Client build unknown (device predates version reporting)">unknown</span>';
             deviceCell = '<div class="dev-label-row">' +
               (d.label ? '<span class="dev-label">' + esc(d.label) + '</span>' : '<span class="dev-label unlabeled">— unlabeled</span>') +
               '<button class="ic-btn ' + (d.label ? '' : 'assign-btn') + '" data-act="editLabel" data-id="' + esc(id) + '" title="' + (d.label ? 'Edit label' : 'Assign label') + '">✏</button>' +
               (startup ? '<span class="badge-startup" title="' + esc(startup) + '">★</span>' : '') +
+              verBadge +
               '</div>';
           }
-          deviceCell += '<div class="dev-sub">' + esc(id) + ' · ' + esc(d.model || '-') + ' · ' + esc(d.ip || '-') +
-            (d.version_name ? ' · v' + esc(d.version_name) + (d.version_code != null ? ' (' + esc(d.version_code) + ')' : '') : '') +
-            '</div>';
+          deviceCell += '<div class="dev-sub">' + esc(id) + ' · ' + esc(d.ip || '-') + '</div>';
 
           let status;
           if (d.status === 'updating') {


### PR DESCRIPTION
Closes #42.

## Context

The self-update work (#39, merged in #48) already added `version_code` / `version_name` to the `REGISTER` protocol, the device registry, and the `DEVICE_LIST` payload. So the remaining work for #42 was making those versions **visible** in the three places an operator needs them.

## Changes

### 1. Server version in the startup log
`Starting STYLY-MDM server vX.Y.Z on port N`. A checkout without git tags (setuptools_scm reports `0.0.0`) renders as `0.0.0 (untagged)` so the line never reads like a real release. `__version__` is imported lazily inside `run_server` to avoid the `__init__` ↔ `server` circular import.

### 2. Client build on the settings screen
The installed build (`v<VERSION_NAME>`) is shown right-aligned in a title-bar row at the top of the settings screen, so an operator holding the headset can read it without ADB. `VERSION_NAME` already carries the `-dev` suffix for the dev flavor.

### 3. Client version in the device list (the headline)
Each device row renders the client build as a right-aligned badge, so badges line up down the right edge of the Device column and laggards are scannable after a rollout. Clients that predate version reporting show a muted `unknown`. The model name was dropped from the device sub-line to make room (per review).

## Verification

- **Server:** full suite `182 passed`; startup log + `(untagged)` fallback checked directly.
- **Client:** `assembleDevDebug` builds the APK cleanly (confirms the layout id + Kotlin change). Layout is build-verified only — not run on a device/emulator in this environment.
- **Console:** real end-to-end render driven via Playwright (fake devices over the websocket) — all badge cases (known / `unknown`), model dropped, a 60-char label wrapping without pushing/clipping the badge, and offline rows keeping their last-known badge. The console is dark-theme only.

## Not included (kept out of scope)

- `GET /api/version` + a console header readout (item 1's *optional* endpoint) — left out to keep the change minimal.
- The group-management device list (`renderMgDevListHtml`) still shows `id · model · ip`; the model was only dropped from the main device list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)