### PR TITLE
fix: keep versionCode/versionName greppable for the release version-bump workflow

### DIFF
--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -11,10 +11,18 @@ android {
         applicationId "com.styly.mdmclient"
         minSdk 29
         targetSdk 33
-        // Overridable so a self-update test run can push a strictly-increasing versionCode
-        // without editing this file. CI passes neither property and gets the committed values.
-        versionCode ((project.findProperty("versionCodeOverride") ?: 6) as Integer)
-        versionName ((project.findProperty("versionNameOverride") ?: "0.2.3").toString())
+        // Keep versionCode/versionName on plain literal lines: the release-version-bump
+        // workflow greps and seds them. Overrides are applied by assignment below so a
+        // self-update test run can push a strictly-increasing versionCode without editing
+        // this file. CI passes neither property and gets the committed values.
+        versionCode 6
+        versionName "0.2.3"
+        if (project.hasProperty("versionCodeOverride")) {
+            versionCode = project.property("versionCodeOverride") as Integer
+        }
+        if (project.hasProperty("versionNameOverride")) {
+            versionName = project.property("versionNameOverride").toString()
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
## Problem

The "Release: bump version & draft" workflow failed: https://github.com/styly-dev/STYLY-MDM/actions/runs/29168659517

## Cause

PR #48 rewrote `mdm-client/app/build.gradle` to make `versionCode`/`versionName` overridable for self-update testing:

```groovy
versionCode ((project.findProperty("versionCodeOverride") ?: 6) as Integer)
versionName ((project.findProperty("versionNameOverride") ?: "0.2.3").toString())
```

`.github/workflows/release-version-bump.yml` greps/seds plain literal lines
(`^[[:space:]]*versionName[[:space:]]+"..."` and
`^[[:space:]]*versionCode[[:space:]]+[0-9]+`). Those patterns no longer match,
so `CURRENT_NAME=$(grep ...)` returns nothing and the step exits under `set -e`.

## Fix

Restore plain literal `versionCode 6` / `versionName "0.2.3"` lines inside
`defaultConfig`, and apply `-PversionCodeOverride` / `-PversionNameOverride`
overrides by assignment right after, so the override behavior added in #48
still works while the workflow's grep/sed pipeline has a literal line to match.

## Verification

- Simulated the workflow's exact grep/sed pipeline (macOS `sed -i '' -E`) against
  the edited file with `VERSION=0.3.0`:
  - `CURRENT_NAME=0.2.3`, `CURRENT_CODE=6` (before)
  - `AFTER_NAME=0.3.0`, `AFTER_CODE=7` (after)
  - `diff` of the temp file vs. the original shows only the two version lines
    changed — no other line was touched.
- `./gradlew help -q` and `./gradlew help -q -PversionCodeOverride=100 -PversionNameOverride=0.9.9-test`
  both configure successfully (Gradle 8.9), confirming the Groovy is valid and
  the override branches execute without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)