### PR TITLE
fix: declare lint dependency on the guard APK copy task

### DIFF
--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -106,7 +106,16 @@ android {
 
 android.applicationVariants.all { variant ->
     def cap = variant.buildType.name.capitalize()
-    variant.mergeAssetsProvider.configure { dependsOn(tasks.named("copyGuardApk${cap}")) }
+    def copyGuard = tasks.named("copyGuardApk${cap}")
+    variant.mergeAssetsProvider.configure { dependsOn(copyGuard) }
+    // Lint scans the assets srcDirs too (lintVitalAnalyze<Variant>,
+    // generate<Variant>LintVitalReportModel, and their non-vital equivalents), so
+    // those tasks must also wait for the guard APK copy. Gradle 8 fails the build
+    // on this implicit dependency otherwise.
+    def variantCap = variant.name.capitalize()
+    tasks.matching { it.name.toLowerCase().contains("lint") && it.name.contains(variantCap) }.configureEach {
+        dependsOn(copyGuard)
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Problem

The v0.3.0 release build ([Build and Release APK #9](https://github.com/styly-dev/STYLY-MDM/actions/runs/29169848146)) failed with:

```
Task ':app:lintVitalAnalyzeProdRelease' uses this output of task ':app:copyGuardApkRelease'
without declaring an explicit or implicit dependency.
```

`copyGuardApk<BuildType>` (added in #51) generates `build/generated/guardApk/<buildType>`, which is registered as an assets srcDir. Only `mergeAssets` declared a dependency on it, but lint vital tasks (which only run on release builds — hence unnoticed in debug builds) also scan the assets srcDirs, and Gradle 8 fails the build on the undeclared dependency.

## Fix

Wire every lint task of a variant (`lintVitalAnalyze<Variant>`, `generate<Variant>LintVitalReportModel`, and their non-vital equivalents) to depend on the corresponding `copyGuardApk<BuildType>` task, alongside the existing `mergeAssets` dependency.

## Verification

`./gradlew :app:lintVitalAnalyzeProdRelease` now completes with BUILD SUCCESSFUL and no implicit-dependency error; `copyGuardApkRelease` is scheduled before the lint tasks.

Note: locally without `KEYSTORE_FILE` the guard release APK is named `guard-release-unsigned.apk`, so the copy task is NO-SOURCE and the guard is silently not embedded — pre-existing behavior, out of scope here (CI sets the signing env and is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)