### PR TITLE
feat: log resolved data-dir paths and ports at server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,20 @@ pip install -e .
 python -m styly_mdm      # or ./run.sh
 ```
 
-The server starts on port 7070 and displays its LAN IP addresses:
+The server starts on port 7070 and displays its LAN IP addresses and the
+resolved data-directory paths (handy because the data directory defaults to the
+current working directory — see the configuration table below):
 
 ```
 2026-02-24 [INFO] Starting STYLY-MDM server on port 7070
 2026-02-24 [INFO]   Server running at http://192.168.1.5:7070
+2026-02-24 [INFO] Configuration:
+2026-02-24 [INFO]   Data directory:   /srv/styly-mdm
+2026-02-24 [INFO]   APK directory:    /srv/styly-mdm/apks
+2026-02-24 [INFO]   Bundle directory: /srv/styly-mdm/bundles
+2026-02-24 [INFO]   Device registry:  /srv/styly-mdm/device_registry.json
+2026-02-24 [INFO]   WebSocket port:   7070
+2026-02-24 [INFO]   Discovery port:   7071
 2026-02-24 [INFO] UDP discovery responder listening on port 7071
 ```
 

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -2819,6 +2819,16 @@ async def run_server(port: int | None = None):
     else:
         log.info("  Server running at http://0.0.0.0:%d", port)
 
+    # Data-dir paths are CWD-relative by default (see DATA_DIR), so log the resolved
+    # locations to make "where does this write" unambiguous at a glance.
+    log.info("Configuration:")
+    log.info("  Data directory:   %s", DATA_DIR)
+    log.info("  APK directory:    %s", APK_DIR)
+    log.info("  Bundle directory: %s", BUNDLE_DIR)
+    log.info("  Device registry:  %s", REGISTRY_PATH)
+    log.info("  WebSocket port:   %d", port)
+    log.info("  Discovery port:   %d", DISCOVERY_PORT)
+
     # Start UDP discovery responder alongside the HTTP server
     discovery_transport = await start_discovery_responder(port, ip_addresses)
 


### PR DESCRIPTION
## Summary

The data directory defaults to the current working directory (`DATA_DIR = Path(os.environ.get("MDM_DATA_DIR", ".")).resolve()`), so where the server writes APKs, bundles, and the device registry depends on where it was started — easy to get wrong and hard to notice.

This adds a `Configuration:` block to the startup log listing the **resolved** data directory and its derived paths, plus the WebSocket and discovery ports:

```
[INFO] Starting STYLY-MDM server v0.3.0 on port 7070
[INFO]   Server running at http://192.168.1.5:7070
[INFO] Configuration:
[INFO]   Data directory:   /srv/styly-mdm
[INFO]   APK directory:    /srv/styly-mdm/apks
[INFO]   Bundle directory: /srv/styly-mdm/bundles
[INFO]   Device registry:  /srv/styly-mdm/device_registry.json
[INFO]   WebSocket port:   7070
[INFO]   Discovery port:   7071
```

Because `run_server()` reads the module globals, the paths reflect the final value regardless of whether it came from `--data-dir`, `MDM_DATA_DIR`, or the CWD default. Timeout/transfer-limit settings are deliberately left out to keep the block readable (medium granularity).

## Changes

- `mdm-server/styly_mdm/server.py` — emit the Configuration block in `run_server()`, right after the running-at URLs.
- `README.md` — update the startup-log sample to match and note the CWD-default caveat.

## Verification

- Syntax check passes.
- Booted `python -m styly_mdm --data-dir <path> --port 7099` and confirmed the block prints the resolved `--data-dir` path and derived paths as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)