### PR TITLE
fix: name release APK styly-mdm-client_<tag>.apk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,8 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           APK=$(find mdm-client/app/build/outputs/apk/prod/release -name "*.apk" | head -1)
-          gh release upload "$RELEASE_TAG" "$APK" --clobber
+          # Upload under a descriptive, versioned name (e.g. styly-mdm-client_v0.3.0.apk)
+          # instead of Gradle's default app-prod-release.apk.
+          ASSET="styly-mdm-client_${RELEASE_TAG}.apk"
+          cp "$APK" "$ASSET"
+          gh release upload "$RELEASE_TAG" "$ASSET" --clobber


### PR DESCRIPTION
## Summary

The release workflow currently uploads the APK under Gradle's default name `app-prod-release.apk`, which doesn't identify the project or version. This renames the uploaded asset to a descriptive, versioned name, e.g. `styly-mdm-client_v0.3.0.apk`.

## Why

- **Identifiable**: distinguishes the STYLY MDM client APK from any other, and shows the version at a glance on the Releases page.
- **Version in filename**: the version is visible after download, preventing mix-ups when distributing to devices.
- **Low cost**: the fix is a rename right before upload; no change to Gradle build config.

## Change

`.github/workflows/release.yml` — copy the built APK to `styly-mdm-client_${RELEASE_TAG}.apk` (the tag is already `vX.Y.Z`, so no double `v`) before `gh release upload`. `RELEASE_TAG` is passed via `env:`, keeping the safe injection pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)