### PR TITLE
feat: stop retrying forever when no server is present (bounded connection window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ STYLY-MDM currently supports PICO devices (PICO OS with Business Mode). Support 
 - **Multi-device launch** — select devices with the checkboxes (use the header checkbox to select all) and send an app launch command to them at once; offline devices are skipped automatically
 - **Persistent device list** — once an HMD has connected it stays in the list with an `online`/`offline` status instead of vanishing on disconnect; offline devices keep their last-known details, can be pre-labeled, and can be forgotten when decommissioned
 - **Battery monitoring** — connected clients report battery percentage and charging state, and the console highlights low-battery devices
-- **Auto-reconnect** — both the MDM client and the web console reconnect automatically with exponential backoff
+- **Auto-reconnect with a bounded window** — the web console reconnects automatically with exponential backoff; the MDM client retries (with UDP discovery) only inside a short connection window after a network change or disconnect, then goes fully silent — `Standby (no server found)` — so a fleet running without a server pays no standby-battery or network cost. Toggling Wi-Fi, rebooting, or restarting the client opens a fresh window; the window length and retry interval are configurable via `/sdcard/styly-mdm/config.json` (see [Client standby behavior](#client-standby-behavior-and-how-to-tune-it))
 - **Boot persistence** — the MDM client starts automatically on HMD boot via `BOOT_COMPLETED` and PICO auto-boot intents
 - **Activity log** — every launch command and result is shown in the web console with timestamps
 - **APK deployment** — upload an APK from the web console and install it silently on selected online devices
@@ -115,6 +115,42 @@ Install the MDM client APK on the HMD (see the [Developer Guide](docs/DEVELOPMEN
 
 The MDM client connects to the server, registers the device (serial number, model, IP address), and runs as a foreground service in the background.
 
+### Client standby behavior (and how to tune it)
+
+The mdm-server does not have to run permanently: at an installed venue it may be
+started only when devices actually need to be managed. The client is designed so that
+an unreachable server never drains device batteries or puts useless traffic on the
+venue network:
+
+- After a network change, an app restart, or losing an established connection, the
+  client tries to find a server for a short **connection window** (default **10
+  seconds**, one discovery + connect attempt every **2 seconds**).
+- If no server is found in time, it stops all network traffic and shows
+  **`Standby (no server found)`** in its notification and settings screen. A standby
+  client sends nothing at all — no reconnect attempts, no discovery broadcasts, no
+  pings — so the Wi-Fi radio can stay in power-save and the device pays no
+  standby-battery cost for a server that is not there.
+- A standby client does **not** notice a server that starts up later. To bring a device
+  back under management, give it a new connection window: **toggle Wi-Fi off/on**,
+  **reboot the device**, or restart the client app — with the server running.
+
+Both durations can be changed per device by placing an optional JSON file at
+`/sdcard/styly-mdm/config.json`:
+
+```json
+{ "connect_window_seconds": 10, "connect_retry_interval_seconds": 2 }
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `connect_window_seconds` | 10 | How long the client keeps searching before going to standby |
+| `connect_retry_interval_seconds` | 2 | Delay between attempts inside the window |
+
+Place it with `adb push` (or the headset's file manager), or deliver it to a connected
+fleet with the console's file-push feature. The file is re-read every time a new
+connection window opens, so changes take effect on the next Wi-Fi toggle, disconnect,
+or reboot — no reinstall needed. Missing or invalid values fall back to the defaults.
+
 ### 3. Launch Apps from the Web Console
 
 1. Open `http://<server-ip>:7070` in a browser.
@@ -159,7 +195,13 @@ Device labels and group definitions live in a single file, `<data-dir>/device_re
    styly-mdm --data-dir /srv/styly-mdm
    ```
 
-Devices rediscover the new server over UDP and reconnect on their own. The `ip` and `last_seen` fields refresh on reconnect, and group membership is keyed by serial number, so devices that are offline during the move keep their groups.
+Devices do **not** reconnect on their own: while the old server was down they went to
+standby (see [Client standby behavior](#client-standby-behavior-and-how-to-tune-it)),
+and a standby client does not notice the new server. Once the new server is running,
+toggle Wi-Fi off/on or reboot each headset — the fresh connection window rediscovers
+the new server over UDP and reconnects. The `ip` and `last_seen` fields refresh on
+reconnect, and group membership is keyed by serial number, so devices that are offline
+during the move keep their groups.
 
 Uploaded APKs (`<data-dir>/apks/`) and pushed file bundles (`<data-dir>/bundles/`) are not part of the registry. Copy those directories separately with `rsync` or `scp` if the new server needs them — a single APK can be up to 2 GiB, so they are not worth moving through a browser.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,7 +167,9 @@ STYLY-MDM/
     │   └── java/com/styly/mdmclient/
     │       ├── MdmClientApplication.kt   # Application entry point
     │       ├── MdmClientService.kt       # Foreground service; executes launch commands
-    │       ├── WebSocketManager.kt       # WebSocket connection with auto-reconnect
+    │       ├── WebSocketManager.kt       # WebSocket connection inside the bounded connection window
+    │       ├── ConnectionScheduler.kt    # Connection-window state machine (host-JVM tested)
+    │       ├── ClientConfig.kt           # Window/retry tunables + config-file overrides (host-JVM tested)
     │       ├── SettingsActivity.kt       # UI to configure server URL; shows client build; Update Journal viewer
     │       ├── ServerDiscovery.kt        # UDP broadcast server discovery
     │       ├── BundleSync.kt             # Push/sync a file bundle into a device directory
@@ -756,9 +758,9 @@ increase (`-PversionCodeOverride`).
 ## Device Retirement
 
 At final venue handover the MDM client must not remain on delivered devices (issue #49):
-an orphaned client reconnect-loops and broadcasts discovery packets on the customer's
-network indefinitely, and an unmanaged remote-control agent should not ship with delivered
-hardware. The console's **Retire Devices** command makes selected clients uninstall
+an orphaned client still probes for a server on every network transition (and, before the
+bounded connection window, reconnect-looped indefinitely), and an unmanaged
+remote-control agent should not ship with delivered hardware. The console's **Retire Devices** command makes selected clients uninstall
 themselves — the same `pbsControlAPPManger(PACKAGE_SILENCE_UNINSTALL, <own package>)`
 primitive the guard's self-destruct uses (device-verified there, including that TobService
 accepts an uninstall of the calling package).
@@ -790,8 +792,8 @@ The flow inverts the self-update's success signal: a removed client can send not
    `retiring`. Both failure modes surface well inside the window: a client whose
    uninstall never ran still holds its WebSocket (checked directly at the deadline), and
    a merely-killed client is restarted by the keep-alive and re-registers within the
-   ≤30 s reconnect backoff — no reboot is involved, which is why this window is much
-   shorter than `SELF_UPDATE_TIMEOUT`.
+   fresh connection window its process restart opens (seconds) — no reboot is involved,
+   which is why this window is much shorter than `SELF_UPDATE_TIMEOUT`.
 4. Terminal states, reported as `RETIRE_RESULT`:
    * **Success** — the device stayed away for the whole window. The registry record is
      flagged `retired` (persisted in `device_registry.json`), the row turns to the
@@ -822,6 +824,55 @@ client and guard packages are both gone after the retire, and that no ToBService
 keep-alive or appops residue misbehaves (`MANAGE_EXTERNAL_STORAGE` pointing at a removed
 package is inert but worth a glance).
 
+## Client Connection Lifecycle (bounded connection window)
+
+At an installed venue the mdm-server is not necessarily running all the time — it may
+be brought up only when devices need to be managed. The client therefore never retries
+forever (issue #67 — every retry wakes the Wi-Fi radio out of power-save and every
+discovery broadcast lands on the venue network). Instead, connection attempts are only allowed
+inside a **connection window**, driven by a plain-Kotlin state machine
+(`ConnectionScheduler`: `IDLE` / `WINDOW_OPEN` / `CONNECTED` / `SILENT`, host-JVM
+tested) that `WebSocketManager` executes on the main looper:
+
+1. **The window opens on a network-available transition**, not on boot: the client
+   registers a `ConnectivityManager` default-network callback, which also fires
+   immediately when a network is already up — so a process restart (self-update,
+   settings save, reboot) gets a fresh window too. A fresh window likewise opens when
+   an **established connection drops** while the network is still up.
+2. **Inside the window** every attempt cycle runs UDP discovery first (a saved-but-stale
+   URL must not keep the client away from a relocated server), then connects to the
+   saved URL, which discovery just refreshed if a server answered. Failed attempts
+   retry on a fixed interval; OkHttp's `connectTimeout` is shortened to 3 s so a single
+   black-holed attempt cannot consume the window.
+3. **On expiry without a connection** the in-flight socket is aborted (`cancel()`, no
+   close handshake) and the client goes fully **silent** — no WebSocket attempts, no
+   UDP, no pings — showing `Standby (no server found)` in the notification and
+   Settings screen. Losing the network cancels everything the same way (`IDLE`).
+4. **Recovery from silence** is any new network-available transition: toggling Wi-Fi,
+   rebooting while the server is up, or restarting the client process.
+
+### Connection tunables (`/sdcard/styly-mdm/config.json`)
+
+The window duration and retry interval have built-in defaults and can be overridden by
+an optional JSON file on shared storage — placed by an operator (file manager / `adb
+push`) or delivered to a connected fleet via `EXECUTE_PUSH_FILES` (the path is outside
+the protected top-level media dirs precisely so a push bundle may write it):
+
+```json
+{ "connect_window_seconds": 10, "connect_retry_interval_seconds": 2 }
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `connect_window_seconds` | 10 | How long after a network-available transition (or a connection drop) the client keeps trying before going silent |
+| `connect_retry_interval_seconds` | 2 | Delay between attempt cycles inside the window |
+
+Each key falls back to its default independently when missing or invalid
+(non-numeric/non-positive); fractional seconds are accepted. The file is re-read every
+time a window opens, so a pushed config takes effect on the next network transition or
+disconnect — no reinstall or reboot. A device that has never reached a server can only
+run on the defaults (the push channel needs a live socket).
+
 ## Server Discovery Protocol
 
 STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.
@@ -831,7 +882,10 @@ STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.
 | 1 | Client → Broadcast | Send `STYLYMDM_DISCOVER` as UTF-8 to `255.255.255.255:7071` (UDP) |
 | 2 | Server → Client | Respond with JSON: `{"service": "stylymdm", "ws_url": "ws://<ip>:7070/ws/device", "version": "1.0"}` |
 
-The client waits up to 3 seconds for a response. If no server replies, discovery fails silently and the client falls back to the default or saved URL.
+The client runs one discovery exchange at the start of every attempt cycle inside its
+[connection window](#client-connection-lifecycle-bounded-connection-window), waiting up
+to 3 seconds for a response. If no server replies, discovery fails silently and the
+cycle proceeds against the saved (or default) URL.
 
 > The ports above are the production defaults. A development server/client uses
 > port 7081 (discovery) and 7080 (WebSocket) instead — see

--- a/mdm-client/app/build.gradle
+++ b/mdm-client/app/build.gradle
@@ -132,4 +132,7 @@ dependencies {
     // Host JVM tests. BundleSync deletes files on the device, so its copy-vs-mirror
     // behaviour is proven here rather than only on real hardware.
     testImplementation 'junit:junit:4.13.2'
+    // Android's bundled org.json is a stub on the host JVM; ClientConfig parsing
+    // needs the real implementation to be testable under plain JUnit.
+    testImplementation 'org.json:json:20240303'
 }

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/ClientConfig.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/ClientConfig.kt
@@ -1,0 +1,65 @@
+package com.styly.mdmclient
+
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Tunables for the bounded connection window (#67), overridable by an
+ * operator-placed JSON file on shared storage:
+ *
+ *   /sdcard/styly-mdm/config.json
+ *   { "connect_window_seconds": 10, "connect_retry_interval_seconds": 2 }
+ *
+ * The file is optional; each key falls back to its default independently when
+ * missing or invalid (non-numeric or non-positive). It is re-read every time a
+ * connection window opens, so a pushed config takes effect on the next network
+ * transition or disconnect without reinstalling. The path is deliberately
+ * outside Downloads: EXECUTE_PUSH_FILES refuses the protected top-level media
+ * dirs, so /sdcard/styly-mdm is the one place both an operator (via file
+ * manager or adb) and a push bundle can write. Free of Android imports so
+ * parsing runs under plain JUnit.
+ */
+object ClientConfig {
+
+    const val CONFIG_RELATIVE_PATH = "styly-mdm/config.json"
+
+    const val KEY_CONNECT_WINDOW_SECONDS = "connect_window_seconds"
+    const val KEY_RETRY_INTERVAL_SECONDS = "connect_retry_interval_seconds"
+
+    const val DEFAULT_CONNECT_WINDOW_MS = 10_000L
+    const val DEFAULT_RETRY_INTERVAL_MS = 2_000L
+
+    data class Values(
+        val connectWindowMs: Long = DEFAULT_CONNECT_WINDOW_MS,
+        val retryIntervalMs: Long = DEFAULT_RETRY_INTERVAL_MS,
+    )
+
+    val DEFAULTS = Values()
+
+    fun load(file: File): Values = parse(
+        try {
+            if (file.isFile) file.readText() else null
+        } catch (t: Throwable) {
+            null
+        }
+    )
+
+    fun parse(jsonText: String?): Values {
+        if (jsonText == null) return DEFAULTS
+        val json = try {
+            JSONObject(jsonText)
+        } catch (t: Throwable) {
+            return DEFAULTS
+        }
+        return Values(
+            connectWindowMs = secondsAsMs(json, KEY_CONNECT_WINDOW_SECONDS, DEFAULT_CONNECT_WINDOW_MS),
+            retryIntervalMs = secondsAsMs(json, KEY_RETRY_INTERVAL_SECONDS, DEFAULT_RETRY_INTERVAL_MS),
+        )
+    }
+
+    private fun secondsAsMs(json: JSONObject, key: String, defaultMs: Long): Long {
+        val seconds = json.optDouble(key)
+        if (seconds.isNaN() || seconds.isInfinite() || seconds <= 0.0) return defaultMs
+        return (seconds * 1000.0).toLong()
+    }
+}

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/ConnectionScheduler.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/ConnectionScheduler.kt
@@ -1,0 +1,115 @@
+package com.styly.mdmclient
+
+/**
+ * Decides when the client may generate network traffic (#67). In serverless
+ * deployments there is usually no mdm-server to find, so instead of retrying
+ * forever the client gets a bounded connection window anchored on network
+ * availability: attempts run inside the window on a fixed retry interval, and
+ * when the window expires without a connection the client goes fully silent —
+ * no WebSocket attempts, no UDP discovery — until the network transitions
+ * again (Wi-Fi off/on, reboot, process restart).
+ *
+ * Pure Kotlin: the current time and the config values are injected and every
+ * side effect is returned as an [Action] for the caller to execute, so the
+ * window logic runs under plain JUnit like [PowerCycleSchedule].
+ */
+class ConnectionScheduler(
+    private val config: () -> ClientConfig.Values,
+) {
+
+    enum class State { IDLE, WINDOW_OPEN, CONNECTED, SILENT }
+
+    sealed class Action {
+        /** Begin a discovery-then-connect attempt now. */
+        object StartAttempt : Action()
+
+        /** Re-enter [StartAttempt] after [delayMs] (report via onRetryElapsed). */
+        data class ScheduleRetry(val delayMs: Long) : Action()
+
+        /** Arm the window deadline timer (report via onWindowExpired). */
+        data class ScheduleWindowExpiry(val delayMs: Long) : Action()
+
+        /** Remove any pending retry and window-expiry timers. */
+        object CancelTimers : Action()
+
+        /** Abort the in-flight attempt: cancel the socket without a close handshake. */
+        object CancelAttempt : Action()
+
+        /** No server was found within the window — surface standby status. */
+        object EnterSilence : Action()
+    }
+
+    var state: State = State.IDLE
+        private set
+
+    private var windowDeadline = 0L
+    private var retryIntervalMs = ClientConfig.DEFAULT_RETRY_INTERVAL_MS
+
+    /** A (new) default network became available. */
+    fun onNetworkAvailable(now: Long): List<Action> = when (state) {
+        State.IDLE, State.SILENT -> openWindow(now, cancelAttempt = false)
+        // The default network changed mid-window: restart the cycle on the new one.
+        State.WINDOW_OPEN -> openWindow(now, cancelAttempt = true)
+        // A healthy connection stays as-is; if the network really changed under
+        // it the socket dies and onSocketDisconnected reopens a window.
+        State.CONNECTED -> emptyList()
+    }
+
+    /** The default network was lost: stop all traffic until one returns. */
+    fun onNetworkLost(): List<Action> = when (state) {
+        State.IDLE -> emptyList()
+        else -> {
+            state = State.IDLE
+            listOf(Action.CancelTimers, Action.CancelAttempt)
+        }
+    }
+
+    /** The WebSocket reached onOpen. */
+    fun onConnected(): List<Action> {
+        state = State.CONNECTED
+        return listOf(Action.CancelTimers)
+    }
+
+    /** The socket died — a failed attempt, or an established connection dropping. */
+    fun onSocketDisconnected(now: Long): List<Action> = when (state) {
+        // The network is still up (otherwise onNetworkLost already ran), so an
+        // established connection dropping opens a fresh window.
+        State.CONNECTED -> openWindow(now, cancelAttempt = false)
+        State.WINDOW_OPEN ->
+            if (now >= windowDeadline) goSilent()
+            else listOf(Action.ScheduleRetry(retryIntervalMs))
+        // Stale callback from a cancelled socket.
+        State.IDLE, State.SILENT -> emptyList()
+    }
+
+    /** A [Action.ScheduleRetry] timer fired. */
+    fun onRetryElapsed(): List<Action> = when (state) {
+        State.WINDOW_OPEN -> listOf(Action.StartAttempt)
+        else -> emptyList()
+    }
+
+    /** A [Action.ScheduleWindowExpiry] timer fired. */
+    fun onWindowExpired(): List<Action> = when (state) {
+        State.WINDOW_OPEN -> goSilent()
+        else -> emptyList()
+    }
+
+    private fun openWindow(now: Long, cancelAttempt: Boolean): List<Action> {
+        // Config is re-read on every window open so an updated config file
+        // takes effect on the next network transition or disconnect.
+        val values = config()
+        state = State.WINDOW_OPEN
+        windowDeadline = now + values.connectWindowMs
+        retryIntervalMs = values.retryIntervalMs
+        val actions = mutableListOf<Action>(Action.CancelTimers)
+        if (cancelAttempt) actions.add(Action.CancelAttempt)
+        actions.add(Action.ScheduleWindowExpiry(values.connectWindowMs))
+        actions.add(Action.StartAttempt)
+        return actions
+    }
+
+    private fun goSilent(): List<Action> {
+        state = State.SILENT
+        return listOf(Action.CancelTimers, Action.CancelAttempt, Action.EnterSilence)
+    }
+}

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
@@ -3,9 +3,12 @@ package com.styly.mdmclient
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
 import android.net.wifi.WifiManager
 import android.os.BatteryManager
 import android.os.Build
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
@@ -18,14 +21,24 @@ import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.json.JSONObject
+import java.io.File
 import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.util.concurrent.TimeUnit
 
 /**
- * Manages WebSocket connection to the STYLY-MDM server.
- * Handles auto-reconnect with exponential backoff, device registration,
- * and dispatching received commands.
+ * Manages WebSocket connection to the STYLY-MDM server: device registration,
+ * dispatching received commands, and the bounded connection window (#67).
+ *
+ * Connection attempts are allowed only inside a window that opens on each
+ * network-available transition (which also covers process restart) and on an
+ * established connection dropping. Inside the window every attempt cycle runs
+ * UDP discovery first and then connects to the saved URL, retrying on a fixed
+ * interval; when the window expires without a connection the client goes fully
+ * silent until the next network transition. Window duration and retry interval
+ * come from [ClientConfig] (defaults overridable via /sdcard/styly-mdm/config.json).
+ * The state logic lives in [ConnectionScheduler]; all of it runs on the main
+ * looper via [reconnectHandler].
  */
 class WebSocketManager(
     private val context: Context,
@@ -42,10 +55,9 @@ class WebSocketManager(
         // never falls back to the production port and accidentally connects to a
         // production server. The IP is just a placeholder; discovery is the real path.
         val DEFAULT_SERVER_URL = "ws://192.168.1.100:${BuildConfig.DEFAULT_WS_PORT}/ws/device"
-        private const val INITIAL_RECONNECT_DELAY_MS = 1000L
-        private const val MAX_RECONNECT_DELAY_MS = 30000L
-        private const val DISCOVERY_INTERVAL_MS = 15000L
-        private const val DISCOVERY_FAILURE_THRESHOLD = 3
+        // Short enough that a single black-holed connect attempt cannot consume
+        // the whole connection window (OkHttp's default would be 10 s).
+        private const val CONNECT_TIMEOUT_SECONDS = 3L
         private const val PING_INTERVAL_SECONDS = 15L
         private const val BATTERY_UPDATE_INTERVAL_MS = 5 * 60 * 1000L
 
@@ -54,17 +66,47 @@ class WebSocketManager(
     }
 
     private val client = OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .pingInterval(PING_INTERVAL_SECONDS, TimeUnit.SECONDS)
         .readTimeout(0, TimeUnit.MILLISECONDS)
         .build()
 
     private var webSocket: WebSocket? = null
-    private var reconnectDelay = INITIAL_RECONNECT_DELAY_MS
     private var isRunning = false
-    private var consecutiveFailures = 0
     private val reconnectHandler = Handler(Looper.getMainLooper())
     private val reconnectToken = Object()
     private val batteryTelemetryToken = Object()
+
+    private val scheduler = ConnectionScheduler {
+        ClientConfig.load(File(Environment.getExternalStorageDirectory(), ClientConfig.CONFIG_RELATIVE_PATH))
+    }
+
+    // Invalidates the in-flight discovery thread when its attempt is cancelled.
+    private var attemptGeneration = 0
+
+    // registerDefaultNetworkCallback can report the new network's onAvailable
+    // before the old network's onLost when the default network switches; only
+    // the loss of the network we currently consider active may close the window.
+    private var activeNetwork: Network? = null
+    private var networkCallbackRegistered = false
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            reconnectHandler.post {
+                if (!isRunning) return@post
+                activeNetwork = network
+                dispatch(scheduler.onNetworkAvailable(SystemClock.uptimeMillis()))
+            }
+        }
+
+        override fun onLost(network: Network) {
+            reconnectHandler.post {
+                if (!isRunning || network != activeNetwork) return@post
+                activeNetwork = null
+                onStatusChanged(false, "Waiting for network...")
+                dispatch(scheduler.onNetworkLost())
+            }
+        }
+    }
 
     fun getServerUrl(): String {
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
@@ -78,27 +120,22 @@ class WebSocketManager(
 
     fun connect() {
         isRunning = true
-        // If no URL has been explicitly saved, try auto-discovery first
-        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-        if (!prefs.contains(PREF_SERVER_URL)) {
-            onStatusChanged(false, "Discovering server...")
-            Thread {
-                val discovered = ServerDiscovery.discover()
-                if (discovered != null && isValidWsUrl(discovered)) {
-                    Log.i(TAG, "Auto-discovered server: $discovered")
-                    setServerUrl(discovered)
-                } else {
-                    Log.i(TAG, "Auto-discovery failed, using default URL")
-                }
-                reconnectHandler.post { doConnect() }
-            }.start()
-        } else {
-            doConnect()
-        }
+        onStatusChanged(false, "Waiting for network...")
+        // The connection window is anchored on network availability, not on
+        // service start: the callback fires immediately when a network is
+        // already up, and again on every later network-available transition.
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        cm.registerDefaultNetworkCallback(networkCallback)
+        networkCallbackRegistered = true
     }
 
     fun disconnect() {
         isRunning = false
+        if (networkCallbackRegistered) {
+            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            cm.unregisterNetworkCallback(networkCallback)
+            networkCallbackRegistered = false
+        }
         reconnectHandler.removeCallbacksAndMessages(null)
         webSocket?.close(1000, "Client disconnecting")
         webSocket = null
@@ -125,6 +162,68 @@ class WebSocketManager(
         }
     }
 
+    /** Executes the side effects the scheduler decided on. Main looper only. */
+    private fun dispatch(actions: List<ConnectionScheduler.Action>) {
+        for (action in actions) {
+            when (action) {
+                is ConnectionScheduler.Action.StartAttempt -> startAttempt()
+                is ConnectionScheduler.Action.ScheduleRetry -> {
+                    onStatusChanged(false, "Reconnecting in ${action.delayMs / 1000}s...")
+                    reconnectHandler.postAtTime(
+                        { dispatch(scheduler.onRetryElapsed()) },
+                        reconnectToken,
+                        SystemClock.uptimeMillis() + action.delayMs
+                    )
+                }
+                is ConnectionScheduler.Action.ScheduleWindowExpiry -> {
+                    reconnectHandler.postAtTime(
+                        { dispatch(scheduler.onWindowExpired()) },
+                        reconnectToken,
+                        SystemClock.uptimeMillis() + action.delayMs
+                    )
+                }
+                is ConnectionScheduler.Action.CancelTimers ->
+                    reconnectHandler.removeCallbacksAndMessages(reconnectToken)
+                is ConnectionScheduler.Action.CancelAttempt -> cancelAttempt()
+                is ConnectionScheduler.Action.EnterSilence -> {
+                    Log.i(TAG, "No server found within the connection window, going silent")
+                    onStatusChanged(false, "Standby (no server found)")
+                }
+            }
+        }
+    }
+
+    /**
+     * One attempt cycle: UDP discovery first (a saved-but-stale URL must not
+     * keep the client away from a relocated server), then connect to the saved
+     * URL — which discovery just refreshed if a server answered.
+     */
+    private fun startAttempt() {
+        val generation = ++attemptGeneration
+        onStatusChanged(false, "Discovering server...")
+        Thread {
+            val discovered = ServerDiscovery.discover()
+            reconnectHandler.post {
+                if (!isRunning || generation != attemptGeneration ||
+                    scheduler.state != ConnectionScheduler.State.WINDOW_OPEN
+                ) return@post
+                if (discovered != null && isValidWsUrl(discovered)) {
+                    Log.i(TAG, "Discovered server at: $discovered")
+                    setServerUrl(discovered)
+                }
+                doConnect()
+            }
+        }.start()
+    }
+
+    private fun cancelAttempt() {
+        attemptGeneration++
+        // cancel() aborts without a close handshake — the window expired or the
+        // network vanished, so there is nothing to say goodbye to.
+        webSocket?.cancel()
+        webSocket = null
+    }
+
     private fun doConnect() {
         if (!isRunning) return
 
@@ -138,12 +237,12 @@ class WebSocketManager(
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 Log.i(TAG, "WebSocket connected")
                 reconnectHandler.post {
-                    reconnectDelay = INITIAL_RECONNECT_DELAY_MS
-                    consecutiveFailures = 0
+                    if (this@WebSocketManager.webSocket !== webSocket) return@post
+                    dispatch(scheduler.onConnected())
+                    onStatusChanged(true, "Connected")
+                    sendRegistration()
+                    startBatteryTelemetry()
                 }
-                onStatusChanged(true, "Connected")
-                sendRegistration()
-                startBatteryTelemetry()
             }
 
             override fun onMessage(webSocket: WebSocket, text: String) {
@@ -166,64 +265,24 @@ class WebSocketManager(
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 Log.i(TAG, "WebSocket closed: $code $reason")
-                onStatusChanged(false, "Disconnected: $reason")
-                stopBatteryTelemetry()
-                scheduleReconnect()
+                onSocketGone(webSocket, "Disconnected: $reason")
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 Log.e(TAG, "WebSocket failure: ${t.message}")
-                onStatusChanged(false, "Connection failed: ${t.message}")
-                stopBatteryTelemetry()
-                scheduleReconnect()
+                onSocketGone(webSocket, "Connection failed: ${t.message}")
             }
         })
     }
 
-    private fun scheduleReconnect() {
-        // Post to main looper to ensure all reconnect state is accessed from a single thread
+    /** Routes a dead socket into the scheduler, ignoring cancelled/stale sockets. */
+    private fun onSocketGone(deadSocket: WebSocket, message: String) {
         reconnectHandler.post {
-            if (!isRunning) return@post
-
-            // Cancel any previously scheduled reconnect to prevent duplicate attempts
-            reconnectHandler.removeCallbacksAndMessages(reconnectToken)
-
-            consecutiveFailures++
-
-            if (consecutiveFailures >= DISCOVERY_FAILURE_THRESHOLD) {
-                // Saved URL isn't working — switch to discovery mode.
-                // Once in this branch, discovery runs on every reconnect cycle
-                // (every DISCOVERY_INTERVAL_MS) until a connection succeeds.
-                Log.i(TAG, "Connection failed $consecutiveFailures times, attempting server discovery")
-                onStatusChanged(false, "Discovering server...")
-
-                reconnectHandler.postAtTime({
-                    Thread {
-                        val discovered = ServerDiscovery.discover()
-                        reconnectHandler.post {
-                            if (discovered != null && isValidWsUrl(discovered)) {
-                                Log.i(TAG, "Discovered server at: $discovered")
-                                setServerUrl(discovered)
-                                consecutiveFailures = 0
-                                reconnectDelay = INITIAL_RECONNECT_DELAY_MS
-                            } else {
-                                Log.i(TAG, "Server discovery failed, will retry")
-                            }
-                            doConnect()
-                        }
-                    }.start()
-                }, reconnectToken, SystemClock.uptimeMillis() + DISCOVERY_INTERVAL_MS)
-            } else {
-                // First few failures — retry saved URL with exponential backoff
-                Log.i(TAG, "Reconnecting in ${reconnectDelay}ms")
-                onStatusChanged(false, "Reconnecting in ${reconnectDelay / 1000}s...")
-
-                reconnectHandler.postAtTime({
-                    doConnect()
-                }, reconnectToken, SystemClock.uptimeMillis() + reconnectDelay)
-
-                reconnectDelay = (reconnectDelay * 2).coerceAtMost(MAX_RECONNECT_DELAY_MS)
-            }
+            if (webSocket !== deadSocket) return@post
+            webSocket = null
+            stopBatteryTelemetry()
+            onStatusChanged(false, message)
+            dispatch(scheduler.onSocketDisconnected(SystemClock.uptimeMillis()))
         }
     }
 

--- a/mdm-client/app/src/test/java/com/styly/mdmclient/ClientConfigTest.kt
+++ b/mdm-client/app/src/test/java/com/styly/mdmclient/ClientConfigTest.kt
@@ -1,0 +1,85 @@
+package com.styly.mdmclient
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class ClientConfigTest {
+
+    @Test
+    fun nullTextYieldsDefaults() {
+        assertEquals(ClientConfig.DEFAULTS, ClientConfig.parse(null))
+    }
+
+    @Test
+    fun garbageYieldsDefaults() {
+        assertEquals(ClientConfig.DEFAULTS, ClientConfig.parse("not json at all"))
+    }
+
+    @Test
+    fun emptyObjectYieldsDefaults() {
+        assertEquals(ClientConfig.DEFAULTS, ClientConfig.parse("{}"))
+    }
+
+    @Test
+    fun bothKeysOverride() {
+        val values = ClientConfig.parse(
+            """{"connect_window_seconds": 30, "connect_retry_interval_seconds": 5}"""
+        )
+        assertEquals(30_000L, values.connectWindowMs)
+        assertEquals(5_000L, values.retryIntervalMs)
+    }
+
+    @Test
+    fun partialOverrideKeepsOtherDefault() {
+        val values = ClientConfig.parse("""{"connect_window_seconds": 42}""")
+        assertEquals(42_000L, values.connectWindowMs)
+        assertEquals(ClientConfig.DEFAULT_RETRY_INTERVAL_MS, values.retryIntervalMs)
+    }
+
+    @Test
+    fun fractionalSecondsAreSupported() {
+        val values = ClientConfig.parse("""{"connect_retry_interval_seconds": 0.5}""")
+        assertEquals(500L, values.retryIntervalMs)
+    }
+
+    @Test
+    fun nonPositiveValuesFallBackToDefaults() {
+        val values = ClientConfig.parse(
+            """{"connect_window_seconds": 0, "connect_retry_interval_seconds": -3}"""
+        )
+        assertEquals(ClientConfig.DEFAULTS, values)
+    }
+
+    @Test
+    fun nonNumericValuesFallBackToDefaults() {
+        val values = ClientConfig.parse(
+            """{"connect_window_seconds": "ten", "connect_retry_interval_seconds": null}"""
+        )
+        assertEquals(ClientConfig.DEFAULTS, values)
+    }
+
+    @Test
+    fun invalidKeyFallsBackWithoutAffectingValidKey() {
+        val values = ClientConfig.parse(
+            """{"connect_window_seconds": "bogus", "connect_retry_interval_seconds": 4}"""
+        )
+        assertEquals(ClientConfig.DEFAULT_CONNECT_WINDOW_MS, values.connectWindowMs)
+        assertEquals(4_000L, values.retryIntervalMs)
+    }
+
+    @Test
+    fun loadMissingFileYieldsDefaults() {
+        val dir = Files.createTempDirectory("clientconfig").toFile()
+        assertEquals(ClientConfig.DEFAULTS, ClientConfig.load(File(dir, "config.json")))
+    }
+
+    @Test
+    fun loadReadsFileContent() {
+        val file = File.createTempFile("clientconfig", ".json")
+        file.deleteOnExit()
+        file.writeText("""{"connect_window_seconds": 15}""")
+        assertEquals(15_000L, ClientConfig.load(file).connectWindowMs)
+    }
+}

--- a/mdm-client/app/src/test/java/com/styly/mdmclient/ConnectionSchedulerTest.kt
+++ b/mdm-client/app/src/test/java/com/styly/mdmclient/ConnectionSchedulerTest.kt
@@ -1,0 +1,156 @@
+package com.styly.mdmclient
+
+import com.styly.mdmclient.ConnectionScheduler.Action
+import com.styly.mdmclient.ConnectionScheduler.State
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConnectionSchedulerTest {
+
+    private fun scheduler(
+        windowMs: Long = ClientConfig.DEFAULT_CONNECT_WINDOW_MS,
+        retryMs: Long = ClientConfig.DEFAULT_RETRY_INTERVAL_MS,
+    ) = ConnectionScheduler { ClientConfig.Values(windowMs, retryMs) }
+
+    @Test
+    fun networkAvailableOpensWindowAndStartsAttempt() {
+        val s = scheduler()
+        val actions = s.onNetworkAvailable(now = 1_000L)
+        assertEquals(State.WINDOW_OPEN, s.state)
+        assertTrue(actions.contains(Action.StartAttempt))
+        assertTrue(actions.contains(Action.ScheduleWindowExpiry(ClientConfig.DEFAULT_CONNECT_WINDOW_MS)))
+    }
+
+    @Test
+    fun failureInsideWindowSchedulesRetryAtConfiguredInterval() {
+        val s = scheduler(windowMs = 10_000L, retryMs = 7_000L)
+        s.onNetworkAvailable(now = 0L)
+        val actions = s.onSocketDisconnected(now = 3_000L)
+        assertEquals(listOf<Action>(Action.ScheduleRetry(7_000L)), actions)
+        assertEquals(State.WINDOW_OPEN, s.state)
+    }
+
+    @Test
+    fun retryElapsedStartsNextAttemptWhileWindowOpen() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        assertEquals(listOf<Action>(Action.StartAttempt), s.onRetryElapsed())
+    }
+
+    @Test
+    fun windowExpiryCancelsAttemptAndEntersSilence() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        val actions = s.onWindowExpired()
+        assertEquals(State.SILENT, s.state)
+        assertTrue(actions.contains(Action.CancelAttempt))
+        assertTrue(actions.contains(Action.EnterSilence))
+        // Once silent, stale socket callbacks and timers must produce no traffic.
+        assertEquals(emptyList<Action>(), s.onSocketDisconnected(now = 99_000L))
+        assertEquals(emptyList<Action>(), s.onRetryElapsed())
+        assertEquals(emptyList<Action>(), s.onWindowExpired())
+    }
+
+    @Test
+    fun failureAtOrPastDeadlineEntersSilenceWithoutRetry() {
+        val s = scheduler(windowMs = 10_000L)
+        s.onNetworkAvailable(now = 0L)
+        val actions = s.onSocketDisconnected(now = 10_000L)
+        assertEquals(State.SILENT, s.state)
+        assertTrue(actions.contains(Action.EnterSilence))
+    }
+
+    @Test
+    fun networkRegainedAfterSilenceOpensFreshWindow() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        s.onWindowExpired()
+        assertEquals(State.SILENT, s.state)
+        // Wi-Fi off does not reopen anything...
+        s.onNetworkLost()
+        assertEquals(State.IDLE, s.state)
+        // ...Wi-Fi back on does — the non-reboot recovery path.
+        val actions = s.onNetworkAvailable(now = 60_000L)
+        assertEquals(State.WINDOW_OPEN, s.state)
+        assertTrue(actions.contains(Action.StartAttempt))
+    }
+
+    @Test
+    fun networkLostCancelsEverythingAndBlocksRetries() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        val actions = s.onNetworkLost()
+        assertEquals(State.IDLE, s.state)
+        assertTrue(actions.contains(Action.CancelTimers))
+        assertTrue(actions.contains(Action.CancelAttempt))
+        // A cancelled socket reporting failure while idle must not reopen a window.
+        assertEquals(emptyList<Action>(), s.onSocketDisconnected(now = 1_000L))
+        assertEquals(emptyList<Action>(), s.onRetryElapsed())
+    }
+
+    @Test
+    fun establishedConnectionDropOpensFreshWindow() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        assertEquals(listOf<Action>(Action.CancelTimers), s.onConnected())
+        assertEquals(State.CONNECTED, s.state)
+        val actions = s.onSocketDisconnected(now = 500_000L)
+        assertEquals(State.WINDOW_OPEN, s.state)
+        assertTrue(actions.contains(Action.StartAttempt))
+        assertTrue(actions.contains(Action.ScheduleWindowExpiry(ClientConfig.DEFAULT_CONNECT_WINDOW_MS)))
+        // The fresh window is anchored on the drop time, not the original window.
+        assertEquals(
+            listOf<Action>(Action.ScheduleRetry(ClientConfig.DEFAULT_RETRY_INTERVAL_MS)),
+            s.onSocketDisconnected(now = 500_001L)
+        )
+    }
+
+    @Test
+    fun networkAvailableWhileConnectedIsIgnored() {
+        val s = scheduler()
+        s.onNetworkAvailable(now = 0L)
+        s.onConnected()
+        assertEquals(emptyList<Action>(), s.onNetworkAvailable(now = 5_000L))
+        assertEquals(State.CONNECTED, s.state)
+    }
+
+    @Test
+    fun networkChangeMidWindowRestartsTheWindow() {
+        val s = scheduler(windowMs = 10_000L)
+        s.onNetworkAvailable(now = 0L)
+        val actions = s.onNetworkAvailable(now = 8_000L)
+        assertEquals(State.WINDOW_OPEN, s.state)
+        assertTrue(actions.contains(Action.CancelAttempt))
+        assertTrue(actions.contains(Action.StartAttempt))
+        assertTrue(actions.contains(Action.ScheduleWindowExpiry(10_000L)))
+        // Deadline moved to 8s + 10s: a failure at 12s is still inside the window.
+        assertEquals(
+            listOf<Action>(Action.ScheduleRetry(ClientConfig.DEFAULT_RETRY_INTERVAL_MS)),
+            s.onSocketDisconnected(now = 12_000L)
+        )
+    }
+
+    @Test
+    fun customConfigValuesAreHonored() {
+        val s = scheduler(windowMs = 60_000L, retryMs = 5_000L)
+        val open = s.onNetworkAvailable(now = 0L)
+        assertTrue(open.contains(Action.ScheduleWindowExpiry(60_000L)))
+        assertEquals(listOf<Action>(Action.ScheduleRetry(5_000L)), s.onSocketDisconnected(now = 59_999L))
+        s.onSocketDisconnected(now = 60_000L)
+        assertEquals(State.SILENT, s.state)
+    }
+
+    @Test
+    fun configIsReReadAtEachWindowOpen() {
+        var values = ClientConfig.Values(connectWindowMs = 10_000L, retryIntervalMs = 2_000L)
+        val s = ConnectionScheduler { values }
+        s.onNetworkAvailable(now = 0L)
+        s.onWindowExpired()
+        // Operator pushes a new config while the device sits silent.
+        values = ClientConfig.Values(connectWindowMs = 30_000L, retryIntervalMs = 9_000L)
+        val actions = s.onNetworkAvailable(now = 100_000L)
+        assertTrue(actions.contains(Action.ScheduleWindowExpiry(30_000L)))
+        assertEquals(listOf<Action>(Action.ScheduleRetry(9_000L)), s.onSocketDisconnected(now = 100_001L))
+    }
+}

--- a/mdm-server/scripts/watch_discovery.py
+++ b/mdm-server/scripts/watch_discovery.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Watch for client UDP discovery broadcasts on the LAN.
+
+Prints one timestamped line per received datagram. Useful to prove a client
+has gone silent after its connection window expired (issue #67): run this with
+the server STOPPED (it binds the same discovery port) and confirm broadcasts
+stop arriving once the client shows "Standby (no server found)".
+
+Usage:
+    python scripts/watch_discovery.py            # dev port 7081
+    python scripts/watch_discovery.py --port 7071  # production port
+"""
+
+import argparse
+import datetime
+import socket
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=7081,
+        help="discovery port to listen on (default: 7081, the dev port)",
+    )
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("", args.port))
+    print(f"Listening for discovery broadcasts on UDP {args.port} (Ctrl-C to stop)", flush=True)
+    while True:
+        data, addr = sock.recvfrom(1024)
+        now = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        print(f"{now}  {addr[0]}  {data!r}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #67

## Problem

When no mdm-server is reachable, the client retries the WebSocket forever (1 s → 30 s exponential backoff) and, after 3 failures, broadcasts UDP discovery every 15 s indefinitely. Every retry wakes the Wi-Fi radio out of power-save, so a serverless deployment pays a permanent standby-battery cost and keeps emitting packets on the venue network.

## Approach (as agreed in #67)

- **Bounded connection window anchored on network availability.** A `ConnectivityManager` default-network callback opens a window (default 10 s) on each network-available transition — which also covers process restart — and a fresh window opens when an established connection drops.
- **Discovery-first attempt cycles.** Inside the window each cycle runs UDP discovery first (a saved-but-stale URL can no longer starve discovery), then connects to the saved URL, retrying on a fixed interval (default 2 s). `connectTimeout` is shortened to 3 s so one black-holed attempt cannot consume the window.
- **Total silence on expiry.** The in-flight socket is cancelled (no close handshake) and the client stops all traffic — no reconnects, no UDP, no pings — showing `Standby (no server found)`. Recovery is any new window: Wi-Fi off/on, reboot, or app restart.
- **State machine extracted.** `ConnectionScheduler` (`IDLE` / `WINDOW_OPEN` / `CONNECTED` / `SILENT`) is plain Kotlin with time and config injected, returning actions for `WebSocketManager` to execute on the main looper — unit-tested on the host JVM like `PowerCycleSchedule`.

### Config-file overrides

Window duration and retry interval keep built-in defaults but can be overridden per device via `/sdcard/styly-mdm/config.json`:

```json
{ "connect_window_seconds": 10, "connect_retry_interval_seconds": 2 }
```

Per-key fallback on missing/invalid values; the file is re-read at every window open, so a config delivered by `adb push` or `EXECUTE_PUSH_FILES` takes effect on the next network transition or disconnect without reinstalling. The path is outside the protected top-level media dirs precisely so the push channel may write it.

### Races handled

- OkHttp callbacks from a cancelled/stale socket are ignored via socket-identity comparison.
- The in-flight discovery thread is invalidated by an attempt-generation counter.
- `registerDefaultNetworkCallback` may deliver `onAvailable(new)` before `onLost(old)` on a network switch; tracking the active network keeps the stale `onLost` from closing the fresh window.

## Docs

- README gains an operator-facing **Client standby behavior (and how to tune it)** section (guarantee-first wording: an unreachable server never drains batteries or floods the network).
- The **Migrating to Another Server** section is corrected: standby devices no longer reconnect on their own — toggle Wi-Fi or reboot each headset once the new server is up.
- `DEVELOPMENT.md` documents the lifecycle, the config keys, and updates the retire/discovery sections that referenced the old backoff.
- New `mdm-server/scripts/watch_discovery.py` observes discovery broadcasts (used below to prove silence).

## Verification

- **Host JVM tests:** 23 new (`ConnectionSchedulerTest` 12, `ClientConfigTest` 11); full `:app:testDevDebugUnitTest` green, `:app:compileProdReleaseKotlin` green.
- **On device (PICO A9210, dev flavor):**
  - process restart → network callback → discovery → `Connected` in ~0.5 s;
  - server stopped while connected → fresh window, 2 s-interval cycles, `Standby (no server found)` at exactly +10.0 s;
  - silence proven: ~4.5 min with **zero** UDP datagrams on the discovery port (receiver liveness confirmed with a test datagram) and zero client log activity;
  - config override `{30, 5}` → `Reconnecting in 5s...`, silence at exactly +30.0 s, no reinstall;
  - recovery: device stays silent while the server comes up (by design), then Wi-Fi off/on → `Connected` ~0.1 s after the network returns.
- Not exercised: standby-battery measurement over a long sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)