### PR TITLE
feat: offer the client APK as a console download link (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The **data directory** holds everything the server persists: uploaded APKs (`apk
 
 ### 2. Configure the MDM Client
 
+> **Getting the APK.** A released server already holds a matching signed client APK, and the web console's top bar offers it as a **⬇ Client APK v`<version>`** download link — so you can grab the APK for sideloading straight from the console, without visiting this repository's releases page. The link is hidden when the server has no client APK (a from-source run that has never had one uploaded).
+
 Install the MDM client APK on the HMD (see the [Developer Guide](docs/DEVELOPMENT.md) for build and install instructions), then:
 
 1. Launch **STYLY-MDM Client** on the HMD.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,6 +143,38 @@ Repeated runs continue numbering, so counts add up; dummies use the serial prefi
 `DUMMY-TEST-` (override with `--prefix`) and are removed by that prefix. Only offline
 devices can be forgotten, so stop an `--online` run before `--remove`.
 
+### Seeding a client APK for UI testing
+
+**A server run from source holds no client APK at all.** The signed
+`styly-mdm-client_<version>.apk` is placed in `styly_mdm/client/` by CI at release
+time and shipped inside the *wheel*; the source tree has no such directory, so
+`seed_bundled_client_apk()` has nothing to copy and `latest_client_apk()` returns
+`None`. Everything driven by `CLIENT_APK_INFO` is therefore invisible from source:
+the top-bar **⬇ Client APK** download link *and* the per-device **Update** button.
+This is expected — on a released server (`pip`/`uvx`) both always appear.
+
+To exercise them, put one file matching the release naming convention in the
+server's `APK_DIR`. No restart is needed for the file itself, but `CLIENT_APK_INFO`
+is only sent on admin connect and after an upload, so **reload the console** (or
+upload through the console, which re-broadcasts it).
+
+```bash
+# A throwaway server on its own ports and its own data dir
+mkdir -p /tmp/mdm-dev/apks
+# any real APK will do; the name is what the server keys on. Newest dev build:
+cp "$(ls -t mdm-server/apks/app-dev-debug-*.apk | head -1)" \
+   /tmp/mdm-dev/apks/styly-mdm-client_v0.3.0.apk
+cd mdm-server
+MDM_DISCOVERY_PORT=7099 PYTHONPATH=. python -m styly_mdm \
+  --data-dir /tmp/mdm-dev --port 7079
+```
+
+> **Use a separate data directory, not your everyday one.** `CLIENT_APK_INFO` feeds
+> the per-device **Update** button too, so a debug-signed dev APK sitting in the data
+> directory you use with real headsets makes the console offer it as a legitimate
+> client update. Android rejects the install (different signing key), but the console
+> shows a genuine-looking Update button for an APK that can never apply.
+
 ## Project Structure
 
 ```
@@ -238,7 +270,7 @@ STYLY-MDM/
 | Endpoint | Description |
 |---|---|
 | `POST /api/apks` | Multipart upload with field `apk`. Returns `apk_url`, `apk_filename`, and `size`. |
-| `GET /apks/{filename}` | Serves uploaded APK files to devices on the LAN. |
+| `GET /apks/{filename}` | Serves uploaded APK files to devices on the LAN, and backs the console's top-bar client-APK download link (see the client-APK download note below). |
 | `POST /api/bundles` | Multipart upload with repeated field `files`; each part's filename carries its folder-relative path. The server zips the reconstructed tree into a bundle, excluding OS metadata (`.DS_Store`, `._*`, `Thumbs.db`, …). Returns `bundle_url`, `bundle_filename`, `size`, `entry_count` (files in the bundle), and `skipped_count` (files excluded). 400 if every uploaded file was excluded. |
 | `GET /bundles/{filename}` | Serves generated file/folder bundles (zip) to devices on the LAN. |
 
@@ -247,7 +279,7 @@ STYLY-MDM/
 | Message type | Description |
 |---|---|
 | `SERVER_INFO` | Server identity, sent once on connect (before the first `DEVICE_LIST`). Fields: `version` (the `styly_mdm` package version; the console renders it next to the `STYLY-MDM` brand in the top bar. Its `major.minor` is the compatibility reference — and the top-bar value itself turns red when a live client is on a *newer* `major.minor` (i.e. the server is the one lagging). See the compatibility note below). |
-| `CLIENT_APK_INFO` | The newest styly-mdm-client APK the server holds, sent on connect (right after `SERVER_INFO`, before `DEVICE_LIST`) and re-broadcast after every APK upload. Field: `apk` = `{filename, url, version}` or `null`. Drives the per-device **Update** button (see the client-update note below). |
+| `CLIENT_APK_INFO` | The newest styly-mdm-client APK the server holds, sent on connect (right after `SERVER_INFO`, before `DEVICE_LIST`) and re-broadcast after every APK upload. Field: `apk` = `{filename, url, version}` or `null`. Drives the per-device **Update** button and the top-bar client-APK download link (see the notes below). |
 | `DEVICE_LIST` | Current list of known devices. Fields: `devices` (array; each entry carries `status` (`online` / `offline` / `updating` — while a self-update's recovery is in flight — / `retiring` — announced a self-uninstall, awaiting the retire window — / `retired` — terminal, persisted after a successful retire), `version_code` / `version_name` (the client build, when known — the console renders it as a right-aligned badge per row, or `unknown` for clients that predate version reporting; a *stable-online* client whose `version_name` trails the server on `major.minor` is flagged red as needing an update — the reverse case, a client *ahead* of the server, reddens the top-bar server version instead. `updating` and offline rows are exempt, and the check is skipped only when the server version is the `0.0.0` untagged/not-installed fallback), and may include optional `battery`: `{level, charging, last_seen}`) |
 | `LAUNCH_SENT` | Confirmation that commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
 | `INSTALL_SENT` | Confirmation that an install job was accepted (dispatch is throttled and runs in the background). Fields: `apk_filename`, `apk_url`, `target_count`, `max_concurrent` |
@@ -302,6 +334,18 @@ STYLY-MDM/
 > package-data glob); an **sdist** source build does not (setuptools-scm only packs
 > git-tracked files), but `pip`/`uvx` install the wheel — so a released server ships
 > with its matching client, while a from-source run relies on an operator upload.
+
+> **Downloading the client APK from the console.** The same APK that drives the
+> per-device **Update** button is also offered to the operator directly: when
+> `CLIENT_APK_INFO` carries an `apk`, the console's top bar shows a
+> **⬇ Client APK v`<version>`** link pointing at `apk.url` (i.e. the existing
+> `GET /apks/{filename}` static mount — no dedicated download endpoint). It is a
+> plain `<a href download>`, so it works on the non-secure `http://<LAN-IP>` origin
+> the console is normally served from, and aiohttp serves APKs as
+> `application/octet-stream`, so the browser saves rather than renders them. When
+> `apk` is `null` (no client APK in `APK_DIR`) the link is hidden entirely. This
+> means sideloading or hand-installing a client never requires reaching this
+> repository's GitHub Releases page — the console alone is enough.
 
 > **Device groups** are a many-to-many grouping keyed by device serial, persisted
 > server-side in `device_registry.json` (under a `groups` key). Selecting a group

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -67,6 +67,13 @@
     .brand span { color: var(--accent); }
     .brand .brand-version { margin-left: 8px; font-size: 12px; font-weight: 600; color: var(--text-secondary); letter-spacing: 0; }
     .brand .brand-version.mismatch { color: var(--danger); font-weight: 700; }
+    .bar-right { display: flex; align-items: center; gap: 16px; }
+    .apk-download {
+      display: none; align-items: center; gap: 6px; font-size: 13px; font-weight: 600;
+      color: var(--accent); text-decoration: none;
+    }
+    .apk-download.shown { display: flex; }
+    .apk-download:hover { text-decoration: underline; }
     .conn { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); }
     .conn-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--danger); transition: background .3s; }
     .conn-dot.connected { background: var(--success); }
@@ -345,7 +352,10 @@
     <div id="consoleView" class="card">
       <div class="topbar">
         <div class="brand">STYLY-<span>MDM</span><span class="brand-version" id="serverVersion"></span></div>
-        <div class="conn"><span class="conn-dot" id="connDot"></span><span id="connText">Disconnected</span></div>
+        <div class="bar-right">
+          <a class="apk-download" id="clientApkLink" href="#" download>⬇ Client APK</a>
+          <div class="conn"><span class="conn-dot" id="connDot"></span><span id="connText">Disconnected</span></div>
+        </div>
       </div>
 
       <div class="zones">
@@ -639,6 +649,24 @@
         el.classList.toggle('mismatch', behind);
         el.title = behind ? 'Server is behind — a connected client runs a newer major.minor' : '';
       }
+      // Top-bar link that hands the operator the client APK the server already holds,
+      // so sideloading a device does not require reaching the GitHub releases page.
+      // A plain <a download> works on the non-secure http://<LAN-IP> origin the console
+      // is usually served from; hidden entirely when the server has no client APK.
+      function updateClientApkLink() {
+        const el = document.getElementById('clientApkLink');
+        if (!el) return;
+        if (!clientApk) {
+          el.classList.remove('shown');
+          el.removeAttribute('href');
+          return;
+        }
+        el.href = clientApk.url;
+        el.setAttribute('download', clientApk.filename);
+        el.textContent = '⬇ Client APK v' + clientApk.version;
+        el.title = 'Download ' + clientApk.filename + ' to this machine for manual install';
+        el.classList.add('shown');
+      }
       function deviceById(id) { return devices.find(function (d) { return getDeviceId(d) === id; }); }
       // Command targets need a live WebSocket, which "updating" (mid self-update,
       // device rebooting) does not have — only strictly-online devices qualify.
@@ -722,6 +750,7 @@
             // Sent on connect (right after SERVER_INFO, before DEVICE_LIST) and again
             // whenever an APK is uploaded, so the per-device Update buttons stay current.
             clientApk = msg.apk || null;
+            updateClientApkLink();
             if (devices.length) render();
             break;
           }

--- a/mdm-server/tests/test_client_apk.py
+++ b/mdm-server/tests/test_client_apk.py
@@ -5,9 +5,12 @@ client APK; the server finds the newest one in APK_DIR by the release naming
 convention and seeds a wheel-bundled copy into APK_DIR on startup.
 """
 
+import asyncio
 import json
 
+import aiohttp
 import pytest
+from aiohttp.test_utils import TestServer
 
 from styly_mdm import server
 
@@ -96,3 +99,35 @@ def test_seed_bundled_client_apk_copies_once(tmp_path, monkeypatch):
     seeded.write_bytes(b"operator-copy")
     server.seed_bundled_client_apk()
     assert seeded.read_bytes() == b"operator-copy"
+
+
+def test_client_apk_url_is_downloadable_over_http(tmp_path, monkeypatch):
+    """The console's top-bar download link points at latest_client_apk()["url"].
+
+    That URL is only a plain <a href download> away from the operator's browser,
+    so it must resolve to the APK bytes through the ordinary /apks static mount
+    with no extra endpoint and no secure-context-only browser API involved.
+    """
+
+    # create_app() seeds from the real package client/ dir; point it at an empty
+    # one so a locally built wheel's bundled APK cannot outrank the fixture below.
+    monkeypatch.setattr(server, "BUNDLED_CLIENT_DIR", tmp_path / "no-bundle")
+
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        app = server.create_app()
+        (server.APK_DIR / "styly-mdm-client_v0.3.0.apk").write_bytes(b"apk-bytes")
+
+        ts = TestServer(app)
+        await ts.start_server()
+        try:
+            info = server.latest_client_apk()
+            assert info["url"] == "/apks/styly-mdm-client_v0.3.0.apk"
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"http://{ts.host}:{ts.port}{info['url']}") as resp:
+                    assert resp.status == 200
+                    assert await resp.read() == b"apk-bytes"
+        finally:
+            await ts.close()
+
+    asyncio.run(body())


### PR DESCRIPTION
Closes #66.

## Problem

Getting the `styly-mdm-client` APK for sideloading or a manual install required reaching this repository's GitHub Releases page — knowing where the repo lives and having access to it — even though the operator is already sitting in the web console.

## Approach: no new endpoint

The issue guessed this would need "a small HTTP endpoint exposing the file from `APK_DIR`", but that was written before #60 landed. Since #60 the server already:

- seeds the signed client APK into `APK_DIR` on startup (`seed_bundled_client_apk()`),
- serves every file there via `app.router.add_static("/apks", APK_DIR)`,
- and broadcasts `CLIENT_APK_INFO` whose `url` is already `/apks/<filename>`.

The console held `clientApk` from that message but only ever used it to build per-device `INSTALL_APK` jobs. So this change is just a link — no new route, no server change.

## The link

The top bar renders `⬇ Client APK v<version>` pointing at `apk.url`, and hides it entirely when `apk` is `null`.

It is a plain `<a href download>` deliberately. The console is normally served over `http://<LAN-IP>`, which is **not** a secure context, so an implementation built on `fetch`+blob or the File System Access API would silently break in the real deployment. aiohttp serves APKs as `application/octet-stream`, so the browser saves rather than renders them.

## Docs

While verifying this, a pre-existing gap surfaced and is now documented: **a server run from source holds no client APK at all.** The signed APK is placed in `styly_mdm/client/` by CI at release time and ships inside the *wheel*; the source tree has no such directory. So `latest_client_apk()` returns `None` and *nothing* driven by `CLIENT_APK_INFO` is visible from source — this link **and** the per-device **Update** button from #60. New `docs/DEVELOPMENT.md` section explains that and gives a seeding recipe, with a warning to use a separate data directory (a debug-signed dev APK in your everyday one makes the console offer it as a legitimate client update; Android rejects the install, but the UI looks genuine).

## Verification

- `210 passed` — full `mdm-server` suite.
- New test asserts `latest_client_apk()["url"]` is actually GET-able (200 + exact bytes) through a real `TestServer`. It is hermetic — proved with a negative control: dropping a `styly-mdm-client_v9.9.0.apk` into `styly_mdm/client/` (which `create_app()` seeds from) does not change the result, because `BUNDLED_CLIENT_DIR` is monkeypatched to an empty dir.
- **Real browser on the real origin** (`http://<LAN-IP>:7079` — non-secure, *not* localhost), headless Chromium:
  - renders `⬇ Client APK v0.4.0`, `href=/apks/styly-mdm-client_v0.4.0.apk`, `download=styly-mdm-client_v0.4.0.apk`
  - a real click produced a real download — filename and bytes both exact matches
  - with no client APK in `APK_DIR`: `display: none`, `href` removed
- The documented dev-seeding recipe was run end to end (and a bug in the first draft of it — a `cp` glob matching multiple files — was caught and fixed that way).

## Not touched

No `architecture.drawio.svg` / `message-flow.drawio.svg` changes: this reuses the existing `CLIENT_APK_INFO` message and `/apks` route, so neither the architecture nor the message flow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)