### PR TITLE
fix: keep a reconnected device online when its stale socket closes (#70)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -917,6 +917,25 @@ time a window opens, so a pushed config takes effect on the next network transit
 disconnect — no reinstall or reboot. A device that has never reached a server can only
 run on the defaults (the push channel needs a live socket).
 
+### Duplicate connections: the newest registration owns the device
+
+A reboot does not always close the client's socket cleanly — the server can still hold
+the pre-reboot WebSocket open (it only notices at the next 30 s heartbeat) when the
+rebooted client has already reconnected and re-registered. Two live connections then
+carry the same `device_id`, and the invariant is that **the newest `REGISTER` owns the
+entry in `devices`**: `devices[device_id]["ws"]` is the connection every command is sent
+to, and only that connection may tear the entry down.
+
+Every per-connection teardown step in `device_ws_handler` is therefore gated on socket
+identity (`devices[device_id]["ws"] is ws`) — deleting the registration, freeing
+transfer slots, dropping the install-dispatch record, and failing a pending self-update
+verification. Message handlers that index `devices[device_id]` apply the same check and
+ignore frames arriving on a superseded socket.
+
+Without that guard the stale socket's teardown deleted the *live* registration, so a
+reconnected device showed as `offline` in the console until its next `BATTERY_UPDATE`
+raised `KeyError` and killed the surviving connection (issue #70).
+
 ## Server Discovery Protocol
 
 STYLY-MDM supports automatic server discovery via UDP broadcast on the LAN.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -926,11 +926,18 @@ carry the same `device_id`, and the invariant is that **the newest `REGISTER` ow
 entry in `devices`**: `devices[device_id]["ws"]` is the connection every command is sent
 to, and only that connection may tear the entry down.
 
-Every per-connection teardown step in `device_ws_handler` is therefore gated on socket
-identity (`devices[device_id]["ws"] is ws`) — deleting the registration, freeing
-transfer slots, dropping the install-dispatch record, and failing a pending self-update
-verification. Message handlers that index `devices[device_id]` apply the same check and
-ignore frames arriving on a superseded socket.
+`device_ws_handler` enforces that in two places, both via `_owns_device()`:
+
+- **Inbound frames.** One guard above the message dispatch chain drops every
+  device-originated message except `REGISTER` when the socket no longer owns the
+  device_id. Without it a leftover socket could release the live connection's transfer
+  slot (`DOWNLOAD_COMPLETE`), forward a terminal result (`INSTALL_RESULT`,
+  `PUSH_FILES_RESULT`), or consume a self-update verification — finishing the live
+  client's job behind its back. `REGISTER` is the one exception: that is how a
+  connection claims ownership in the first place.
+- **Teardown.** The `finally` block runs only for the owning connection: deleting the
+  registration, freeing transfer slots, dropping the install-dispatch record, and
+  failing a pending self-update verification.
 
 Without that guard the stale socket's teardown deleted the *live* registration, so a
 reconnected device showed as `offline` in the console until its next `BATTERY_UPDATE`

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1234,11 +1234,19 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     if battery is None:
                         log.warning("Invalid BATTERY_UPDATE from %s: %s", device_id, data)
                         continue
+                    # Telemetry from a socket the device has already replaced is not
+                    # worth an unhandled KeyError that takes the live connection's
+                    # handler down with it (#70).
+                    live_entry = devices.get(device_id)
+                    if live_entry is None or live_entry.get("ws") is not ws:
+                        log.info("Ignoring BATTERY_UPDATE from superseded connection: %s",
+                                 device_id)
+                        continue
 
                     # Use server receipt time for stale-display semantics; client clocks
                     # can drift, and the console only needs last-known freshness.
                     battery["last_seen"] = time.time()
-                    devices[device_id]["battery"] = battery
+                    live_entry["battery"] = battery
                     rec = device_registry.get(device_id)
                     if rec is not None:
                         rec["battery"] = battery
@@ -1446,7 +1454,18 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
             elif raw_msg.type == web.WSMsgType.ERROR:
                 log.error("Device WS error: %s", ws.exception())
     finally:
-        if device_id:
+        # A reboot does not always close the old socket cleanly, so the pre-reboot
+        # connection can still be open here when the rebooted client has already
+        # reconnected and re-registered. Every teardown step below belongs to the
+        # connection that currently *owns* the device_id: a superseded socket must
+        # not free the live connection's transfer slots, settle its pending state,
+        # or delete its registration — that last one left a connected device stuck
+        # on "offline" until the next BATTERY_UPDATE crashed the survivor (#70).
+        entry = devices.get(device_id) if device_id else None
+        is_current = entry is not None and entry.get("ws") is ws
+        if device_id and not is_current:
+            log.info("Superseded device connection closed, ignoring: %s", device_id)
+        if device_id and is_current:
             # Free every transfer slot this device was holding — it may have been in
             # an install and a push at once — so a disconnect mid-job does not stall
             # the queue until the timeout fires.
@@ -1476,7 +1495,7 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     "status": "error",
                     "detail": "device disconnected before verification completed",
                 })
-        if device_id and device_id in devices:
+        if device_id and is_current:
             del devices[device_id]
             # Keep the registry entry; just stop reporting the device as online and
             # stamp when it was last seen so it shows as offline in the list.

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1147,6 +1147,21 @@ def zip_tree(root: Path, dest_zip: Path) -> None:
 # Device WebSocket handler  (/ws/device)
 # ---------------------------------------------------------------------------
 
+def _owns_device(device_id: str | None, ws: web.WebSocketResponse) -> bool:
+    """True when ``ws`` is the connection that currently owns ``device_id``.
+
+    A reboot does not always close the client's socket cleanly, so the server can
+    still hold the pre-reboot connection open (it only notices at the next
+    heartbeat) when the rebooted client has already reconnected and re-registered.
+    Both sockets then carry the same device_id, and the newest REGISTER is the
+    owner: ``devices[device_id]["ws"]`` is where commands are sent, so it is also
+    the only connection allowed to mutate that device's state or tear it down
+    (#70).
+    """
+    entry = devices.get(device_id) if device_id else None
+    return entry is not None and entry.get("ws") is ws
+
+
 async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
     ws = web.WebSocketResponse(heartbeat=30)
     await ws.prepare(request)
@@ -1164,6 +1179,17 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     continue
 
                 msg_type = data.get("type")
+
+                # A newer REGISTER has taken ownership of this device_id, so this
+                # socket is a leftover from a reboot the server has not noticed yet.
+                # It must not advance or settle any per-device state — releasing a
+                # transfer slot or forwarding a terminal result from here would
+                # finish the *live* connection's job behind its back (#70). REGISTER
+                # is the one exception: that is how a connection claims ownership.
+                if msg_type != "REGISTER" and device_id and not _owns_device(device_id, ws):
+                    log.info("Ignoring %s from superseded connection: %s",
+                             msg_type, device_id)
+                    continue
 
                 if msg_type == "REGISTER":
                     device_id = data.get("device_id")
@@ -1234,19 +1260,12 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
                     if battery is None:
                         log.warning("Invalid BATTERY_UPDATE from %s: %s", device_id, data)
                         continue
-                    # Telemetry from a socket the device has already replaced is not
-                    # worth an unhandled KeyError that takes the live connection's
-                    # handler down with it (#70).
-                    live_entry = devices.get(device_id)
-                    if live_entry is None or live_entry.get("ws") is not ws:
-                        log.info("Ignoring BATTERY_UPDATE from superseded connection: %s",
-                                 device_id)
-                        continue
-
                     # Use server receipt time for stale-display semantics; client clocks
                     # can drift, and the console only needs last-known freshness.
                     battery["last_seen"] = time.time()
-                    live_entry["battery"] = battery
+                    # The ownership guard above the dispatch chain has already dropped
+                    # frames from a superseded socket, so the entry is present here.
+                    devices[device_id]["battery"] = battery
                     rec = device_registry.get(device_id)
                     if rec is not None:
                         rec["battery"] = battery
@@ -1454,15 +1473,12 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
             elif raw_msg.type == web.WSMsgType.ERROR:
                 log.error("Device WS error: %s", ws.exception())
     finally:
-        # A reboot does not always close the old socket cleanly, so the pre-reboot
-        # connection can still be open here when the rebooted client has already
-        # reconnected and re-registered. Every teardown step below belongs to the
-        # connection that currently *owns* the device_id: a superseded socket must
-        # not free the live connection's transfer slots, settle its pending state,
-        # or delete its registration — that last one left a connected device stuck
-        # on "offline" until the next BATTERY_UPDATE crashed the survivor (#70).
-        entry = devices.get(device_id) if device_id else None
-        is_current = entry is not None and entry.get("ws") is ws
+        # Every teardown step below belongs to the connection that currently owns
+        # the device_id: a superseded socket must not free the live connection's
+        # transfer slots, settle its pending state, or delete its registration —
+        # that last one left a connected device stuck on "offline" until the next
+        # BATTERY_UPDATE crashed the survivor (#70). See _owns_device.
+        is_current = _owns_device(device_id, ws)
         if device_id and not is_current:
             log.info("Superseded device connection closed, ignoring: %s", device_id)
         if device_id and is_current:

--- a/mdm-server/tests/test_duplicate_connection.py
+++ b/mdm-server/tests/test_duplicate_connection.py
@@ -1,0 +1,210 @@
+"""Tests for superseded device connections (issue #70).
+
+A reboot does not always close the old socket cleanly, so the pre-reboot
+WebSocket can still be open server-side when the rebooted client reconnects and
+re-registers. Two connections then carry the same device_id, and the server must
+treat the *newest* registration as the owner:
+
+  * the stale socket's teardown must not delete the live registration (the
+    original bug: the console showed a connected device as "offline"),
+  * nor free the live connection's transfer slots or settle its pending state,
+  * telemetry arriving late on the stale socket must be ignored rather than
+    raise KeyError and take the surviving connection's handler down with it,
+  * and a normal single-connection disconnect must still go offline as before.
+
+Structured like test_retire.py: deterministic unit tests with FakeWS, plus
+aiohttp integration tests over loopback that prove the real handler wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import aiohttp
+import pytest
+from aiohttp.test_utils import TestServer
+
+from styly_mdm import server
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    collections = (
+        server.devices, server.admin_connections, server.pending_transfers,
+        server._transfer_tasks, server.pending_self_updates, server.pending_retires,
+        server._apk_hash_cache, server.device_registry, server.device_groups,
+    )
+    for coll in collections:
+        coll.clear()
+    server.reset_transfer_slots()
+    yield
+    for coll in collections:
+        coll.clear()
+    server.reset_transfer_slots()
+
+
+async def _recv_type(ws, msg_type: str, timeout: float = 2.0) -> dict | None:
+    try:
+        while True:
+            msg = await asyncio.wait_for(ws.receive(), timeout)
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(msg.data)
+                if data.get("type") == msg_type:
+                    return data
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING,
+                              aiohttp.WSMsgType.ERROR):
+                return None
+    except asyncio.TimeoutError:
+        return None
+
+
+async def _register(session, base: str, device_id: str):
+    ws = await session.ws_connect(base + "/ws/device")
+    await ws.send_json({
+        "type": "REGISTER", "device_id": device_id, "model": "M",
+        "ip": "1.1.1.2", "version_code": 7, "version_name": "t",
+    })
+    return ws
+
+
+def _row(device_list: dict, device_id: str) -> dict:
+    return next(d for d in device_list["devices"] if d["device_id"] == device_id)
+
+
+def test_e2e_stale_connection_teardown_keeps_the_live_device_online(tmp_path):
+    """The reported bug: the pre-reboot socket's teardown evicted the live one."""
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                # The pre-reboot connection, still open server-side.
+                stale = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["status"] == "online"
+
+                # The rebooted client reconnects and re-registers.
+                live = await _register(session, base, "dev0")
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["status"] == "online"
+
+                # The stale socket finally dies. The device is still connected,
+                # so it must stay online.
+                await stale.close()
+                await asyncio.sleep(0.1)
+                assert "dev0" in server.devices
+                assert server.devices["dev0"]["ws"] is not None
+
+                # And the live connection still works end to end.
+                await live.send_json({
+                    "type": "BATTERY_UPDATE", "level": 55, "charging": False,
+                })
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["status"] == "online"
+                assert _row(dl, "dev0")["battery"]["level"] == 55
+                assert not live.closed
+
+                await live.close()
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())
+
+
+def test_e2e_battery_update_on_a_superseded_socket_is_ignored(tmp_path):
+    """Late telemetry must not raise KeyError and kill the surviving handler."""
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                stale = await _register(session, base, "dev0")
+                live = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                assert await _recv_type(admin, "DEVICE_LIST") is not None
+
+                # Telemetry from the socket the device has already replaced.
+                await stale.send_json({
+                    "type": "BATTERY_UPDATE", "level": 11, "charging": False,
+                })
+                await asyncio.sleep(0.1)
+                assert server.devices["dev0"].get("battery") is None
+
+                # The live connection is untouched and still owns the device.
+                await live.send_json({
+                    "type": "BATTERY_UPDATE", "level": 66, "charging": True,
+                })
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["battery"]["level"] == 66
+                assert not live.closed
+
+                await stale.close()
+                await live.close()
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())
+
+
+def test_e2e_single_connection_disconnect_still_goes_offline(tmp_path):
+    """The guard must not keep a genuinely gone device pinned online."""
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                only = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["status"] == "online"
+
+                await only.close()
+                dl = await _recv_type(admin, "DEVICE_LIST")
+                assert _row(dl, "dev0")["status"] == "offline"
+                assert "dev0" not in server.devices
+                assert server.device_registry["dev0"]["last_seen"] > 0
+
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())
+
+
+def test_e2e_stale_teardown_does_not_free_the_live_transfer_slot(tmp_path):
+    """A superseded socket closing must not release the live device's slot."""
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                stale = await _register(session, base, "dev0")
+                live = await _register(session, base, "dev0")
+                await asyncio.sleep(0.1)
+
+                slot = asyncio.get_running_loop().create_future()
+                server.pending_transfers[("dev0", server.TASK_INSTALL)] = slot
+
+                await stale.close()
+                await asyncio.sleep(0.1)
+                assert not slot.done(), "stale teardown freed the live device's slot"
+
+                await live.close()
+                await asyncio.sleep(0.1)
+                assert slot.done()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())

--- a/mdm-server/tests/test_duplicate_connection.py
+++ b/mdm-server/tests/test_duplicate_connection.py
@@ -181,6 +181,91 @@ def test_e2e_single_connection_disconnect_still_goes_offline(tmp_path):
     asyncio.run(body())
 
 
+def test_e2e_download_complete_on_a_superseded_socket_does_not_release_the_slot(tmp_path):
+    """A stale socket must not advance the live connection's install (PR #71 review).
+
+    The job was dispatched to the connection that owns the device_id; a leftover
+    socket reporting progress would finish it behind the live client's back.
+    """
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                stale = await _register(session, base, "dev0")
+                live = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                assert await _recv_type(admin, "DEVICE_LIST") is not None
+                await asyncio.sleep(0.1)
+
+                slot = asyncio.get_running_loop().create_future()
+                server.pending_transfers[("dev0", server.TASK_INSTALL)] = slot
+
+                await stale.send_json({
+                    "type": "DOWNLOAD_COMPLETE", "task": server.TASK_INSTALL,
+                    "apk_filename": "x.apk",
+                })
+                await asyncio.sleep(0.1)
+                assert not slot.done(), "stale socket released the live install's slot"
+                assert await _recv_type(admin, "INSTALL_PROGRESS", timeout=0.3) is None
+
+                # The owning connection still drives the job.
+                await live.send_json({
+                    "type": "DOWNLOAD_COMPLETE", "task": server.TASK_INSTALL,
+                    "apk_filename": "x.apk",
+                })
+                await asyncio.sleep(0.1)
+                assert slot.done()
+
+                await stale.close()
+                await live.close()
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())
+
+
+def test_e2e_terminal_result_on_a_superseded_socket_is_not_forwarded(tmp_path):
+    """INSTALL_RESULT from a leftover socket must not settle the live job."""
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                stale = await _register(session, base, "dev0")
+                live = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                assert await _recv_type(admin, "DEVICE_LIST") is not None
+                await asyncio.sleep(0.1)
+
+                await stale.send_json({
+                    "type": "INSTALL_RESULT", "device_id": "dev0",
+                    "status": "fail", "detail": "from the stale socket",
+                })
+                assert await _recv_type(admin, "INSTALL_RESULT", timeout=0.3) is None
+
+                # The owning connection's result still reaches the console.
+                await live.send_json({
+                    "type": "INSTALL_RESULT", "device_id": "dev0",
+                    "status": "success", "detail": "",
+                })
+                forwarded = await _recv_type(admin, "INSTALL_RESULT")
+                assert forwarded is not None and forwarded["status"] == "success"
+
+                await stale.close()
+                await live.close()
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())
+
+
 def test_e2e_stale_teardown_does_not_free_the_live_transfer_slot(tmp_path):
     """A superseded socket closing must not release the live device's slot."""
     async def body():


### PR DESCRIPTION
Fixes #70.

## Problem

A reboot does not always close the client's WebSocket cleanly, so the server can still
hold the pre-reboot connection open (it only notices at the next 30 s heartbeat) when
the rebooted client has already reconnected and re-registered. The disconnect path keyed
on `device_id` alone:

```python
if device_id and device_id in devices:
    del devices[device_id]
```

so the stale socket's teardown deleted the registration belonging to the **live**
connection. The console then showed a fully connected device as `offline` until its next
`BATTERY_UPDATE` hit `devices[device_id]`, raised `KeyError`, and killed the surviving
connection — an unhandled crash was the only recovery path, roughly 5 minutes later.

Observed on DEV-001 (`PA94U0MGKA220311G`): ESTABLISHED socket on both ends, no
`going silent` in the client log, `DEVICE_LIST` reporting `offline`, and the registry
showing a REGISTER and a disconnect 0.8 s apart.

## Change

`devices[device_id]["ws"]` is the connection every command is sent to, so it is now also
the only connection allowed to tear the entry down. Every per-connection teardown step in
`device_ws_handler` is gated on socket identity — deleting the registration, freeing
transfer slots, dropping the install-dispatch record, failing a pending self-update
verification — and `BATTERY_UPDATE` applies the same check, ignoring frames from a
superseded socket instead of raising.

No client-side change: the client was behaving correctly throughout.

## Verification

- `mdm-server/tests/test_duplicate_connection.py` — four aiohttp integration tests over
  loopback covering the eviction, the late-telemetry `KeyError`, the transfer slot, and a
  regression guard that a genuinely gone device still goes offline. Three of the four fail
  against the pre-fix handler.
- Full suite: 214 passed.

Not yet re-checked against the running dev server on hardware — that needs a server
restart, so the reboot-and-watch confirmation is left to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)