### PR TITLE
fix: keep selected devices visible when a filter is active (#72)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -124,6 +124,17 @@ device list scrolling, and the Devices-list / group-picker **filter and sort** c
 (filter matches the device name/label; sort by device name, ascending or descending). It
 is a dev-only helper and is not shipped in the wheel.
 
+On the main Devices list the filter never hides a **selected** device: the visible set is
+`matching ∪ selected`, so a device staged for a command always has a row, and the header
+select-all cannot report a state that is untrue of the whole selection. A row kept only
+because it is selected is marked with an amber wash so it stays distinguishable from a
+genuine match. The Manage Groups picker is unaffected — it filters strictly by query,
+because group membership is a durable roster rather than a set of pending command targets.
+
+A consequence worth knowing: selecting a group stages every member, so a filter applied
+afterwards cannot narrow it — the members stay on screen, marked. That is deliberate, since
+those members are exactly what an action would dispatch to.
+
 It registers through the live `/ws/device` WebSocket rather than editing
 `device_registry.json`, because a running server owns that file: any register/battery/
 group change triggers `save_registry()`, which rewrites the file from in-memory state

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -170,6 +170,15 @@
     .dev-head { padding-top: 9px; padding-bottom: 9px; border-top: none; font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: .5px; }
     .dev-row.offline { opacity: .55; }
     .dev-row.offline:hover { opacity: .75; }
+    /* Kept only because it is selected, not because it matches the filter (issue #72).
+       Marks the exception, not the matches: matching rows are the majority right after a
+       filter is applied, so styling them would bury the one row that needs attention.
+       An amber wash (--warning), not the accent: a left accent bar reads as a selection
+       affordance, which is the one thing this is NOT signalling — the row is already known
+       to be selected (its checkbox is on); what the wash adds is "outside the filter".
+       Kept rows are dimmed less than plain offline rows so the wash stays legible. */
+    .dev-row.kept { background: rgba(251, 191, 36, .16); }
+    .dev-row.kept.offline { opacity: .7; }
     .dev-cell { min-width: 0; padding-right: 10px; }
     .dev-label-row { display: flex; align-items: center; gap: 6px; }
     .dev-label { font-weight: 600; font-size: 14px; }
@@ -701,7 +710,27 @@
         const q = search.trim().toLowerCase();
         return sortDevices(devices.filter(function (d) { return deviceMatchesQuery(d, q); }), sortKey);
       }
-      function visibleDevices() { return filterSortDevices(deviceSearch, deviceSort); }
+      // The main list shows (matching ∪ selected), not just matching (issue #72). A device
+      // staged for a command must never be hidden by a filter, or an action dispatches to a
+      // row the operator cannot see. This keeps selected ⊆ visible, which is what makes
+      // selectAllState()/toggleSelectAll() correct rather than only correct-looking: with no
+      // hidden selections, "all visible are selected" and "all selected" cannot disagree.
+      // Deliberately not folded into filterSortDevices(): the Manage Groups picker tracks a
+      // different set (manageMembers) and must keep filtering strictly by query.
+      function visibleDevices() {
+        const q = deviceSearch.trim().toLowerCase();
+        return sortDevices(devices.filter(function (d) {
+          return deviceMatchesQuery(d, q) || selectedIds.has(getDeviceId(d));
+        }), deviceSort);
+      }
+      // True when a row is on screen only because it is selected. Marking these keeps the
+      // filter honest: a visible row is either a match or a kept selection, and which one
+      // must be tellable at a glance. Kept rows sort in place rather than pinning to the
+      // top, so selecting a device never makes its row jump.
+      function keptBySelection(d) {
+        const q = deviceSearch.trim().toLowerCase();
+        return !!q && !deviceMatchesQuery(d, q) && selectedIds.has(getDeviceId(d));
+      }
       function groupNames() { return Object.keys(groups).sort(); }
       function offlineMembers(name) { return (groups[name] || []).filter(function (s) { const d = deviceById(s); return d && !isOnline(d); }).length; }
       function batteryHtml(d) {
@@ -1013,6 +1042,7 @@
         const id = getDeviceId(d);
         const checked = selectedIds.has(id);
         const off = !isOnline(d);
+        const kept = keptBySelection(d);
         const startup = d.startup_app && d.startup_app.package_name;
         let deviceCell;
         if (editingLabelId === id) {
@@ -1071,7 +1101,9 @@
           status = '<span class="dot"></span>Online';
         }
 
-        return '<div class="dev-row' + (off ? ' offline' : '') + '" data-row-id="' + esc(id) + '">' +
+        return '<div class="dev-row' + (off ? ' offline' : '') + (kept ? ' kept' : '') + '"' +
+          (kept ? ' title="Does not match the filter - shown because it is selected"' : '') +
+          ' data-row-id="' + esc(id) + '">' +
           '<div class="selbox ' + (checked ? 'on' : '') + '" data-act="toggleDevice" data-id="' + esc(id) + '">' + (checked ? '✓' : '') + '</div>' +
           '<div class="dev-cell">' + deviceCell + '</div>' +
           '<div class="dev-status">' + status + '</div>' +
@@ -1080,9 +1112,11 @@
           '</div>';
       }
 
-      // Header select-all reflects the currently visible (filtered) set, so with a filter
-      // active "select all" means "the rows you can see". Reduces to today's behavior when
-      // the filter is empty (visibleDevices() === all devices).
+      // Header select-all reflects the currently visible set, so with a filter active
+      // "select all" means "the rows you can see". Reduces to today's behavior when the
+      // filter is empty (visibleDevices() === all devices). Accurate for the selection as a
+      // whole, not just a subset, because visibleDevices() keeps selected ⊆ visible: there
+      // are no selected-but-hidden devices for this glyph to misreport (issue #72).
       function selectAllState() {
         const vis = visibleDevices();
         if (!vis.length || !selectedIds.size) return '';
@@ -1216,8 +1250,10 @@
         render();
       }
       function toggleSelectAll() {
-        // Operates on the visible (filtered) set: when a filter is active, select-all
-        // toggles only what the user can see, not the whole hidden fleet.
+        // Operates on the visible set: when a filter is active, select-all toggles only
+        // what the user can see, not the whole hidden fleet. Deselecting reaches the entire
+        // selection (so this always clears to 0) because selected ⊆ visible — see
+        // visibleDevices() (issue #72).
         const vis = visibleDevices();
         const all = vis.length > 0 && vis.every(function (d) { return selectedIds.has(getDeviceId(d)); });
         if (all) vis.forEach(function (d) { selectedIds.delete(getDeviceId(d)); });


### PR DESCRIPTION
Closes #72.

## Problem

Filtering the main Devices list never changed the selection, but it could **hide rows that
were already selected**. The operator was then left with command targets that are staged
for dispatch and invisible at the same time, and the header select-all glyph reported a
state untrue of the actual selection. Reproduces with the name filter alone:

1. Select a few devices.
2. Type a query they do not match — the rows disappear, the devices stay selected.
3. If every remaining visible row is selected, the header renders `✓` ("all selected")
   while selected devices are hidden.
4. Click that `✓` — `toggleSelectAll()` deletes only the visible ids, so the hidden
   selections survive and the badge never reaches 0.

An action dispatched from this state runs against devices that were never on screen.

## Fix

`visibleDevices()` now returns `matching ∪ selected` (main list only), so a staged device
always has a row. This establishes **`selected ⊆ visible`** as an invariant, which makes
`selectAllState()` and `toggleSelectAll()` correct by construction — no counter, no warning,
no new state — since "all visible are selected" and "all selected" can no longer disagree.

`visibleDevices()` is the single choke point (its only consumers are `renderDevicesHtml()`,
`selectAllState()`, `toggleSelectAll()`), so the invariant is established in exactly one
place. `filterSortDevices()` is left untouched, so the **Manage Groups** picker keeps
filtering strictly by query — group membership is a durable roster, not a set of pending
command targets.

A row kept only because it is selected gets an **amber wash** (`--warning`), chosen over a
left accent bar: a bar reads as a selection affordance, and the row is already known to be
selected (its checkbox is on). What the wash adds is "outside the current filter". Kept rows
sort in place rather than pinning, so selecting a device never makes its row jump.

## A consequence worth knowing

Selecting a group stages every member, so a filter applied afterwards **cannot narrow the
group** — all members stay on screen, marked. This is deliberate: group members are exactly
what an action would dispatch to (`.sel-ctx` reads `via group "…" · N offline skipped`), so
hiding them is the same bug at its worst scale. On-screen and acted-on agree.

## Verification

- **Behavioral diff, old vs new** (real helpers extracted from `index.html`, same state):

  | scenario | old | new |
  | --- | --- | --- |
  | `a,b` selected + filter | rows `c`; `a,b` selected and invisible | rows `c,a,b`; `a,b` marked kept |
  | `a,b,c` selected + filter | glyph `✓` while `a,b` hidden | glyph `✓`, all three on screen |
  | click select-all reading `✓` | 2 stay selected and invisible | selection clears to 0 |

- **Real browser** (headless Chromium, the LAN-IP origin `http://192.168.128.214:7099`, not
  localhost), 8 seeded dummy devices: the three rows above reproduced; `#devSearch` kept
  focus and value and `.targets-body` scrollTop held across a background `DEVICE_LIST`
  re-render; a no-match query still rendered the selected row, marked; no marks with an
  empty filter. The **active-group** path verified too (`Shelf A`, 5 of 8; filter `01` →
  1 match + 5 kept). Visual check confirmed the amber wash reads clearly against a plain
  match and stays legible combined with `.dev-row.offline`.
- `pytest` — 216 passed. JS syntax (`vm.Script`), `git diff --check`, and the
  Japanese-character guard over touched files all clean.

## Scope

Console only (`mdm-server/styly_mdm/static/index.html`) + docs. No server, protocol, or
diagram change — nothing in the message flow or architecture changed.
