### PR TITLE
feat: filter the Devices list by connection status (#62)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -116,24 +116,35 @@ The ports come from `BuildConfig` fields defined per flavor in
 > build (e.g. debug over a release install) must be uninstalled first, which clears
 > device-owner status, so you would need to re-provision.
 
-### Seeding dummy devices for UI testing
+### Filtering and selecting devices
 
-`mdm-server/scripts/seed_dummy_devices.py` populates a **running** server with fake
-devices, so you can exercise console UI that only matters at scale — the Manage Groups
-device list scrolling, and the Devices-list / group-picker **filter and sort** controls
-(filter matches the device name/label; sort by device name, ascending or descending). It
-is a dev-only helper and is not shipped in the wheel.
+The main Devices list has a **name filter** (matches the device name/label), a **sort** by
+device name (ascending/descending, toggled from the Device column header), and an **Any /
+Online / Offline** status filter beside the name input. Together they let an operator narrow a
+large fleet — e.g. to the currently-online subset — and select all of the narrowed rows at
+once. `Online` means `status === 'online'`, the same predicate as `getOnlineIds()` and the
+STATUS column's "Online" text, so filtering to Online then selecting all yields a set that
+dispatch does not trim as offline. `Offline` is the complement (`updating` / `retiring` /
+`retired` devices count as offline), so Online and Offline partition the list. The three
+controls compose. They apply to the main Devices list only, not the Manage Groups picker.
 
-On the main Devices list the filter never hides a **selected** device: the visible set is
-`matching ∪ selected`, so a device staged for a command always has a row, and the header
-select-all cannot report a state that is untrue of the whole selection. A row kept only
-because it is selected is marked with an amber wash so it stays distinguishable from a
-genuine match. The Manage Groups picker is unaffected — it filters strictly by query,
+The filter never hides a **selected** device: the visible set is `matching ∪ selected`, so a
+device staged for a command always has a row, and the header select-all cannot report a state
+that is untrue of the whole selection. A row kept only because it is selected (it no longer
+matches the name or status filter) is marked with an amber wash so it stays distinguishable
+from a genuine match. The Manage Groups picker is unaffected — it filters strictly by query,
 because group membership is a durable roster rather than a set of pending command targets.
 
 A consequence worth knowing: selecting a group stages every member, so a filter applied
 afterwards cannot narrow it — the members stay on screen, marked. That is deliberate, since
 those members are exactly what an action would dispatch to.
+
+### Seeding dummy devices for UI testing
+
+`mdm-server/scripts/seed_dummy_devices.py` populates a **running** server with fake
+devices, so you can exercise console UI that only matters at scale — the Manage Groups
+device list scrolling and the Devices-list filter/sort controls described above. It is a
+dev-only helper and is not shipped in the wheel.
 
 It registers through the live `/ws/device` WebSocket rather than editing
 `device_registry.json`, because a running server owns that file: any register/battery/

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -165,6 +165,13 @@
     .sort-arrow { font-size: 9px; color: var(--text-muted); margin-left: 3px; }
     .mg-sort-btn { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 4px; padding: 0 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 7px; color: var(--text-secondary); font-size: 13px; font-family: inherit; cursor: pointer; }
     .mg-sort-btn:hover { border-color: #394056; color: var(--text-primary); }
+    /* Segmented status filter (issue #62): Any / Online / Offline, sharing the card/border
+       tokens with the search input so the toolbar reads as one control strip. */
+    .seg { flex: 0 0 auto; display: inline-flex; background: var(--bg-card); border: 1px solid var(--border); border-radius: 7px; overflow: hidden; }
+    .seg-btn { padding: 0 12px; background: none; border: none; border-left: 1px solid var(--border); color: var(--text-secondary); font-size: 13px; font-family: inherit; cursor: pointer; }
+    .seg-btn:first-child { border-left: none; }
+    .seg-btn:hover { color: var(--text-primary); }
+    .seg-btn.active { background: var(--accent); color: #fff; }
     .dev-table { width: 100%; }
     .dev-row { display: grid; grid-template-columns: 42px minmax(0, 2fr) minmax(76px, .7fr) minmax(96px, .85fr) minmax(92px, 1fr); align-items: center; padding: 10px 0; padding-left: 18px; border-top: 1px solid var(--border-soft); font-size: 13px; }
     .dev-head { padding-top: 9px; padding-bottom: 9px; border-top: none; font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: .5px; }
@@ -381,6 +388,11 @@
           </div>
           <div class="dev-toolbar" id="devToolbar" style="display:none">
             <input class="dev-search-input" id="devSearch" data-dev-search maxlength="64" placeholder="⌕ Filter devices by name…">
+            <div class="seg" id="devStatusFilter" role="group" aria-label="Filter by connection status">
+              <button class="seg-btn active" data-status="any" title="Show all devices">Any</button>
+              <button class="seg-btn" data-status="online" title="Show only devices that are online now">Online</button>
+              <button class="seg-btn" data-status="offline" title="Show only devices that are not online">Offline</button>
+            </div>
           </div>
           <div class="targets-body" id="targetsBody"></div>
         </div>
@@ -558,6 +570,10 @@
       // (selectedIds) is never touched by filtering.
       let deviceSearch = '';
       let deviceSort = 'label-asc';
+      // Main Devices list only (issue #62). 'online' follows getOnlineIds() (status ===
+      // 'online'); 'offline' is the complement, so updating/retiring/retired count as
+      // offline and Online + Offline partition the list.
+      let deviceStatusFilter = 'any';  // 'any' | 'online' | 'offline'
       // Manage view
       let manageSelectedGroup = null;
       let manageMembers = new Set();
@@ -579,6 +595,7 @@
       const targetsBody = document.getElementById('targetsBody');
       const devToolbar = document.getElementById('devToolbar');
       const devSearchInput = document.getElementById('devSearch');
+      const devStatusFilter = document.getElementById('devStatusFilter');
       const selCard = document.getElementById('selCard');
       const apkFile = document.getElementById('apkFile');
       const apkName = document.getElementById('apkName');
@@ -710,6 +727,20 @@
         const q = search.trim().toLowerCase();
         return sortDevices(devices.filter(function (d) { return deviceMatchesQuery(d, q); }), sortKey);
       }
+      // Status filter for the main Devices list (issue #62). 'online' mirrors getOnlineIds()
+      // so "filter to Online then select all" yields a set onlineTargets() will not trim;
+      // 'offline' is the complement (updating/retiring/retired included).
+      function deviceMatchesStatus(d) {
+        if (deviceStatusFilter === 'online') return d.status === 'online';
+        if (deviceStatusFilter === 'offline') return d.status !== 'online';
+        return true;
+      }
+      // A row is a match for the main list when it clears both the name query and the status
+      // filter. Status is just a second dimension of "matching", so the #72 machinery below
+      // (union with the selection, mark the exception) extends to it with no new plumbing.
+      function deviceMatchesFilter(d, q) { return deviceMatchesQuery(d, q) && deviceMatchesStatus(d); }
+      // True when any filter (name or status) is narrowing the list.
+      function deviceFilterActive() { return deviceSearch.trim() !== '' || deviceStatusFilter !== 'any'; }
       // The main list shows (matching ∪ selected), not just matching (issue #72). A device
       // staged for a command must never be hidden by a filter, or an action dispatches to a
       // row the operator cannot see. This keeps selected ⊆ visible, which is what makes
@@ -720,7 +751,7 @@
       function visibleDevices() {
         const q = deviceSearch.trim().toLowerCase();
         return sortDevices(devices.filter(function (d) {
-          return deviceMatchesQuery(d, q) || selectedIds.has(getDeviceId(d));
+          return deviceMatchesFilter(d, q) || selectedIds.has(getDeviceId(d));
         }), deviceSort);
       }
       // True when a row is on screen only because it is selected. Marking these keeps the
@@ -729,7 +760,7 @@
       // top, so selecting a device never makes its row jump.
       function keptBySelection(d) {
         const q = deviceSearch.trim().toLowerCase();
-        return !!q && !deviceMatchesQuery(d, q) && selectedIds.has(getDeviceId(d));
+        return deviceFilterActive() && !deviceMatchesFilter(d, q) && selectedIds.has(getDeviceId(d));
       }
       function groupNames() { return Object.keys(groups).sort(); }
       function offlineMembers(name) { return (groups[name] || []).filter(function (s) { const d = deviceById(s); return d && !isOnline(d); }).length; }
@@ -964,6 +995,7 @@
         const showToolbar = targetTab === 'devices' && devices.length > 0;
         devToolbar.style.display = showToolbar ? '' : 'none';
         if (showToolbar && devSearchInput.value !== deviceSearch) devSearchInput.value = deviceSearch;
+        if (showToolbar) syncStatusFilterButtons();
         targetsBody.innerHTML = targetTab === 'groups' ? renderGroupsHtml() : renderDevicesHtml();
         if (editingLabelId !== null && targetTab === 'devices') {
           const inp = targetsBody.querySelector('[data-label-input]');
@@ -1140,6 +1172,15 @@
         if (box) { box.className = 'selbox ' + selectAllState(); box.textContent = selectAllGlyph(); }
         const arrow = targetsBody.querySelector('.dev-head .sort-arrow');
         if (arrow) arrow.textContent = sortArrowGlyph();
+      }
+
+      // The status segmented control is static (outside targetsBody), so reflect module
+      // state onto it directly rather than re-rendering it.
+      function syncStatusFilterButtons() {
+        const btns = devStatusFilter.querySelectorAll('.seg-btn');
+        for (let i = 0; i < btns.length; i++) {
+          btns[i].classList.toggle('active', btns[i].getAttribute('data-status') === deviceStatusFilter);
+        }
       }
 
       // The cell shows whichever job last touched the device: install, push or verify.
@@ -2205,6 +2246,17 @@
       // driven by the clickable Device column header, handled in the targetsBody click
       // delegation above.)
       devSearchInput.addEventListener('input', function () { deviceSearch = devSearchInput.value; refreshDeviceRows(); });
+
+      // Status filter (issue #62). The control is a static sibling of the rows, so it is not
+      // reached by the targetsBody click delegation — wire it directly. Selection is never
+      // touched (a selected device that leaves the filter stays visible, marked kept).
+      devStatusFilter.addEventListener('click', function (e) {
+        const btn = e.target.closest('.seg-btn');
+        if (!btn) return;
+        deviceStatusFilter = btn.getAttribute('data-status');
+        syncStatusFilterButtons();
+        refreshDeviceRows();
+      });
 
       // Selection card delegation
       selCard.addEventListener('click', function (e) {


### PR DESCRIPTION
Closes #62.

## Problem

On a large fleet only some devices are powered on, and their management numbers do not form a
contiguous block — booting a shelf brings a scattered set online. To act on the
currently-online subset, an operator had to visually scan a 100+ row list and pick out the
online rows one by one. The console already *counts* the online subset and `onlineTargets()`
drops offline devices before dispatch, so the gap was never safety or knowing who is online —
it was **selecting** them.

## Change

Add an **Any / Online / Offline** segmented control to the Devices toolbar, beside the name
filter. Combined with the existing visible-set select-all (#57) this yields "show only Online →
select all → run".

- **Online means `status === 'online'`** — the same predicate as `getOnlineIds()` and the
  STATUS column's "Online" text — so filtering to Online then selecting all yields a set that
  dispatch does **not** trim as offline (no "N offline skipped" warning).
- **Offline is the complement** (`status !== 'online'`, so `updating` / `retiring` / `retired`
  count as offline), making Any = Online + Offline a clean partition.
- **Status is treated as a second dimension of "matching"** (`deviceMatchesFilter` =
  name AND status), so it composes with the name filter and sort, and **inherits the #72
  selected-stays-visible machinery for free**: a selected device that leaves the filter keeps
  its row, marked with the amber wash.
- **Main Devices list only** — `filterSortDevices()` is untouched, so the Manage Groups picker
  still filters strictly by query (group membership is a durable roster, not pending targets).

Console-only: `status` already rides along in `DEVICE_LIST`, so there is **no server change**.
The segmented control is a static sibling of the rows (like the name input), so background
`DEVICE_LIST` re-renders never steal its state or the search focus/scroll.

## Verification

- **Node predicate check** (helpers extracted from `index.html`) over a device set spanning all
  five statuses: `deviceMatchesFilter` for any/online/offline; Online ∪ Offline = all; a
  selected non-matching device is `keptBySelection` under both an Online and an Offline filter;
  no marks when no filter is active.
- **Real browser** (headless Chromium, the **LAN-IP** origin `http://192.168.128.214:7099`, not
  localhost), 14 seeded devices (3 online / 11 offline):
  - Any → all rows; Online → exactly the 3 online rows; Offline → the complement, none online.
  - Status filter composes with the name filter.
  - Online → header select-all selects exactly the visible online rows; `renderActions()` shows
    no "offline skipped".
  - Switching to Offline with those 3 online devices still selected keeps them visible, marked
    with the **full-strength amber wash** (no offline dimming) — this also closes the online+kept
    visual case left unverified in #72.
  - `#devSearch` focus and `.targets-body` scroll survive a background `DEVICE_LIST` re-render
    with a status filter active.
- `pytest` — 216 passed (no server change). JS syntax (`vm.Script`), `git diff --check`, and the
  Japanese-character guard over touched files all clean.

## Scope

Console (`mdm-server/styly_mdm/static/index.html`) + docs. No server, protocol, or diagram
change. Sort-by-status, a "Select online" button, and filtering the Manage Groups picker were
all considered and deliberately left out (recorded on #62).
