### PR TITLE
feat: reboot / power off a managed device from the console (#74)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -250,6 +250,7 @@ STYLY-MDM/
 | `REGISTER` | Sent on connect. Fields: `device_id`, `model`, `ip`, `version_code` (integer), `version_name`, `startup_app` (optional) |
 | `BATTERY_UPDATE` | Battery telemetry. Fields: `device_id`, `level` (integer 0-100), `charging` (boolean), `timestamp` (epoch seconds) |
 | `LAUNCH_RESULT` | Result of an app launch. Fields: `status` (`success`/`fail`), `package_name`, `error` (optional) |
+| `REBOOT_RESULT` / `POWER_OFF_RESULT` | Acknowledgement of a power command. `status` is `accepted` (the client received it and flushed this before invoking the SDK — a successful reboot/shutdown tears down the socket first, so no `success` is ever sent) or `fail` (the SDK rejected the call, so the device stayed up to report it). Fields: `status`, `error` (optional). See [Remote Power Control](#remote-power-control). |
 | `INSTALL_RESULT` | Result of an APK install. Fields: `status` (`success`/`fail`), `apk_filename`, `result_code` (optional), `error` (optional) |
 | `DOWNLOAD_COMPLETE` | Sent right after a download finishes, before the local work it feeds (the install, or the unzip + mirror). Frees the server's transfer slot so the next queued device can start downloading. Fields: `task` (`install` / `push`; absent means `install`), `apk_filename` (install), `dest_path` + `delete_extras` (push). Optional — see the transfer-throttling note below. |
 | `PUSH_FILES_RESULT` | Result of a push or sync. Fields: `status` (`success`/`fail`), `dest_path`, `added`, `updated`, `deleted` (counts; `deleted` is always 0 for a push), `error` (optional) |
@@ -264,6 +265,7 @@ STYLY-MDM/
 | Message type | Description |
 |---|---|
 | `EXECUTE_LAUNCH` | Launch an app. Fields: `package_name`, `extra` |
+| `EXECUTE_REBOOT` / `EXECUTE_POWER_OFF` | Reboot or power off the device immediately via the PICO advanced device-control API (`pbsControlSetDeviceAction`). No fields. See [Remote Power Control](#remote-power-control). |
 | `EXECUTE_INSTALL` | Download and install an APK. Fields: `apk_url`, `apk_filename`, plus `full_sha256` + `cd_sha256` (reference hashes of the file being dispatched; present only when the APK is a local upload in `apks/`). The client verifies the download against `full_sha256` before installing; a **self**-update is refused outright when the hashes are absent. |
 | `EXECUTE_PUSH_FILES` | Download a bundle and apply it to a directory. Fields: `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean; `false` = copy/overwrite only, `true` = full mirror. Read with a `false` default — a missing field must never delete) |
 | `EXECUTE_VERIFY_APK` | Compute `size` + Central-Directory digest (plus diagnostics) for an installed package. Fields: `package_name` |
@@ -275,6 +277,7 @@ STYLY-MDM/
 | Message type | Description |
 |---|---|
 | `LAUNCH_APP` | Launch an app on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `package_name`, `extra_data` |
+| `REBOOT_DEVICE` / `POWER_OFF_DEVICE` | Reboot or power off target devices (the console gates both behind a shared confirmation). Fields: `target_devices` (list of device IDs or `["*"]`; online devices only). See [Remote Power Control](#remote-power-control). |
 | `INSTALL_APK` | Install an uploaded APK on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `apk_url`, `apk_filename` |
 | `PUSH_FILES` | Apply a bundle to a directory on target devices. Fields: `target_devices` (list of device IDs or `["*"]`), `bundle_url`, `bundle_filename`, `dest_path`, `delete_extras` (boolean, optional; only a literal `true` requests a full mirror) |
 | `VERIFY_APK` | Verify an installed package against a local reference on target devices. Fields: `target_devices`, `package_name`. The reference (`size` + CD digest) is computed and compared in the browser and is **never** sent to the server. |
@@ -304,6 +307,7 @@ STYLY-MDM/
 | `CLIENT_APK_INFO` | The newest styly-mdm-client APK the server holds, sent on connect (right after `SERVER_INFO`, before `DEVICE_LIST`) and re-broadcast after every APK upload. Field: `apk` = `{filename, url, version}` or `null`. Drives the per-device **Update** button and the top-bar client-APK download link (see the notes below). |
 | `DEVICE_LIST` | Current list of known devices. Fields: `devices` (array; each entry carries `status` (`online` / `offline` / `updating` — while a self-update's recovery is in flight — / `retiring` — announced a self-uninstall, awaiting the retire window — / `retired` — terminal, persisted after a successful retire), `version_code` / `version_name` (the client build, when known — the console renders it as a right-aligned badge per row, or `unknown` for clients that predate version reporting; a *stable-online* client whose `version_name` trails the server on `major.minor` is flagged red as needing an update — the reverse case, a client *ahead* of the server, reddens the top-bar server version instead. `updating` and offline rows are exempt, and the check is skipped only when the server version is the `0.0.0` untagged/not-installed fallback), and may include optional `battery`: `{level, charging, last_seen}`) |
 | `LAUNCH_SENT` | Confirmation that commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
+| `REBOOT_SENT` / `POWER_OFF_SENT` | Confirmation that reboot/power-off commands were dispatched. Fields: `sent_count`, `target_count` |
 | `INSTALL_SENT` | Confirmation that an install job was accepted (dispatch is throttled and runs in the background). Fields: `apk_filename`, `apk_url`, `target_count`, `max_concurrent` |
 | `INSTALL_PROGRESS` | Live progress of a throttled install job, broadcast on each transfer-slot transition. Fields: `apk_filename`, `apk_url`, `total`, `queued`, `transferring`, `transferred`, `failed`, `done` (boolean, `true` on the final update) |
 | `INSTALL_DEVICE_STATE` | Per-device companion to `INSTALL_PROGRESS`: names the devices that just entered a state, so the console can label each row instead of showing the whole target set as installing. Fields: `device_ids` (array), `state` (`queued` / `transferring` / `installing` / `updating` / `success` / `fail`; `updating` and its terminal `success`/`fail` are emitted only for a client self-update), `apk_filename`, `detail` (failure reason, may be empty) |
@@ -312,6 +316,7 @@ STYLY-MDM/
 | `PUSH_DEVICE_STATE` | The `INSTALL_DEVICE_STATE` twin. Fields: `device_ids` (array), `state` (`queued` / `transferring` / `applying` / `fail`), `dest_path`, `delete_extras` (so the console can name the action), `detail` |
 | `PUSH_FILES_RESULT` | Forwarded file/folder result from a device (adds `device_id`) |
 | `LAUNCH_RESULT` | Forwarded result from a device |
+| `REBOOT_RESULT` / `POWER_OFF_RESULT` | Forwarded power-command acknowledgement from a device (adds `device_id`). `accepted` = received and going down (confirm via the row dropping offline); `fail` = the SDK rejected it. See [Remote Power Control](#remote-power-control). |
 | `INSTALL_RESULT` | Forwarded install result from a device |
 | `VERIFY_SENT` | Confirmation that verify-APK commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
 | `VERIFY_DIR_SENT` | Confirmation that verify-directory commands were dispatched. Fields: `path`, `sent_count`, `target_count` |
@@ -889,6 +894,45 @@ retiring. First-fleet verification checklist (once per firmware, on one unit): t
 client and guard packages are both gone after the retire, and that no ToBService
 keep-alive or appops residue misbehaves (`MANAGE_EXTERNAL_STORAGE` pointing at a removed
 package is inert but worth a glance).
+
+## Remote Power Control
+
+An operator can reboot or power off selected devices from the console's **Power Control**
+section (`REBOOT_DEVICE` / `POWER_OFF_DEVICE` → `EXECUTE_REBOOT` / `EXECUTE_POWER_OFF`,
+fanned out to online targets exactly like `LAUNCH_APP`, un-throttled since the message
+carries no transfer). On the device this is the PICO advanced device-control API,
+`IToBService.pbsControlSetDeviceAction(DEVICE_CONTROL_REBOOT | DEVICE_CONTROL_SHUTDOWN,
+…)` — reachable on the same TobService binder the silent-install path already uses and
+gated by the `pico_advance_interface` manifest flag the client already declares. No new
+permission and no SDK addition were needed; shipping the two command handlers is what
+requires a client update + redeploy.
+
+**Power off while charging.** A PICO headset refuses a full power-off while a USB/charging
+cable is connected unless the device-wide *"power off with USB cable"* setting is enabled —
+so a plain `DEVICE_CONTROL_SHUTDOWN` leaves a cabled (venue) device on. The shutdown path
+therefore calls `pbsControlSetPowerOffwithUSBCable(S_ON, 0)` immediately before the shutdown
+so a cabled device actually powers off. This is a persistent, device-wide setting and the
+trade-off is deliberate: a headset on a charging dock **can be remotely powered off and then
+stranded until it is physically woken** — which is exactly the intended venue capability, and
+why the console gates power-off behind a confirmation. Reboot does not touch this setting (it
+cycles regardless of charge state).
+
+**Outcome model — the success signal is the device going offline, not a RESULT.** A
+successful reboot/shutdown tears down the client process and the WebSocket before any
+`*_RESULT: success` could flush, so the client instead sends `REBOOT_RESULT` /
+`POWER_OFF_RESULT` with `status: accepted` **before** invoking the SDK call (flushing it
+to the wire on a worker thread via `awaitOutboundFlush`), and only ever sends
+`status: fail` when the SDK *rejects* the call — in which case the device stays up and the
+frame reaches the server. The real confirmation is therefore the row dropping **offline**
+(and, for a reboot, reconnecting after ~30–60s), read from the connection status. The
+console logs `accepted` as "watch for it to go offline" and never waits for a success
+frame that cannot come.
+
+Both actions are disruptive (a powered-off headset **cannot be turned back on remotely** —
+it must be woken physically), so the console gates the two buttons behind one shared
+confirmation checkbox plus a per-action `confirm()` dialog naming the targets, mirroring the
+Retire pattern. Offline devices are filtered out of the target set before dispatch (the
+SDK call has to run on the device).
 
 ## Client Connection Lifecycle (bounded connection window)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -910,8 +910,10 @@ requires a client update + redeploy.
 **Power off while charging.** A PICO headset refuses a full power-off while a USB/charging
 cable is connected unless the device-wide *"power off with USB cable"* setting is enabled —
 so a plain `DEVICE_CONTROL_SHUTDOWN` leaves a cabled (venue) device on. The shutdown path
-therefore calls `pbsControlSetPowerOffwithUSBCable(S_ON, 0)` immediately before the shutdown
-so a cabled device actually powers off. This is a persistent, device-wide setting and the
+therefore calls `pbsControlSetPowerOffwithUSBCable(S_ON, 0)` as a **precondition** — before
+the `accepted` ack — so a cabled device actually powers off; if the setting cannot be applied
+the client reports `POWER_OFF_RESULT: fail` and does not proceed, rather than acking
+`accepted` on a device that would stay online. This is a persistent, device-wide setting and the
 trade-off is deliberate: a headset on a charging dock **can be remotely powered off and then
 stranded until it is physically woken** — which is exactly the intended venue capability, and
 why the console gates power-off behind a confirmation. Reboot does not touch this setting (it

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -16,7 +16,9 @@ import android.os.IBinder
 import android.os.SystemClock
 import android.util.Log
 import com.pvr.tobservice.ToBServiceHelper
+import com.pvr.tobservice.enums.PBS_DeviceControlEnum
 import com.pvr.tobservice.enums.PBS_PackageControlEnum
+import com.pvr.tobservice.enums.PBS_SwitchEnum
 import com.pvr.tobservice.interfaces.IIntCallback
 import com.pvr.tobservice.interfaces.IToBServiceProxy
 import org.json.JSONArray
@@ -310,6 +312,12 @@ class MdmClientService : Service() {
             "SET_STARTUP_APP" -> handleSetStartupApp(payload)
             "CLEAR_STARTUP_APP" -> handleClearStartupApp()
             "EXECUTE_SELF_UNINSTALL" -> executeSelfUninstall(payload)
+            "EXECUTE_REBOOT" -> executePowerControl(
+                PBS_DeviceControlEnum.DEVICE_CONTROL_REBOOT, "REBOOT_RESULT"
+            )
+            "EXECUTE_POWER_OFF" -> executePowerControl(
+                PBS_DeviceControlEnum.DEVICE_CONTROL_SHUTDOWN, "POWER_OFF_RESULT"
+            )
             else -> Log.w(TAG, "Unknown command type: $type")
         }
     }
@@ -384,6 +392,84 @@ class MdmClientService : Service() {
             Log.e(TAG, "Failed to launch $packageName", e)
             onResult("fail", e.message ?: "Unknown error")
         }
+    }
+
+    /**
+     * Reboot or power off the device via the PICO advanced device-control API
+     * (`pbsControlSetDeviceAction`), reachable on the same TobService binder the
+     * silent-install path already uses and gated by the `pico_advance_interface`
+     * manifest flag the client already declares.
+     *
+     * A successful reboot/shutdown tears down this process and the WebSocket
+     * before any success frame could reach the server, so the client first
+     * acknowledges receipt with a `*_RESULT: accepted` and flushes it to the wire
+     * (on a worker thread) *before* invoking the SDK call. The real success
+     * signal, server-side, is the device going offline (and, for reboot,
+     * reconnecting). A `*_RESULT: fail` is only ever observed when the SDK
+     * rejects the call — the device stays up, so that frame does flush.
+     *
+     * A PICO headset refuses a full power-off while a USB/charging cable is
+     * connected unless the device-wide "power off with USB cable" setting is
+     * enabled. Venue devices are typically on charge, so the shutdown path
+     * enables it first (reboot is unaffected — it cycles regardless of charge).
+     */
+    private fun executePowerControl(action: PBS_DeviceControlEnum, resultType: String) {
+        Thread {
+            try {
+                val binder = ToBServiceHelper.getInstance().serviceBinder
+                if (binder == null) {
+                    Log.e(TAG, "TobService binder not available for $resultType")
+                    sendPowerResult(resultType, "fail", "TobService not available")
+                    return@Thread
+                }
+                // Acknowledge only once there is a binder to act on (so a missing binder
+                // reports a clean "fail", not "accepted" then "fail"), then give the ack a
+                // bounded chance to reach the wire before the reboot/shutdown takes the
+                // connection down — sendMessage only enqueues.
+                sendPowerResult(resultType, "accepted", "")
+                webSocketManager.awaitOutboundFlush(2_000)
+                if (action == PBS_DeviceControlEnum.DEVICE_CONTROL_SHUTDOWN) {
+                    // Without this the device stays on when powered off while charging.
+                    // The trailing int is the standard TobService ext/process arg (0).
+                    try {
+                        binder.pbsControlSetPowerOffwithUSBCable(PBS_SwitchEnum.S_ON, 0)
+                        Log.i(TAG, "Enabled power-off-with-USB-cable before shutdown")
+                    } catch (e: Throwable) {
+                        Log.w(TAG, "Failed to allow power-off while charging; shutdown may be blocked on a cabled device", e)
+                    }
+                }
+                Log.i(TAG, "Invoking pbsControlSetDeviceAction: $action")
+                binder.pbsControlSetDeviceAction(action, object : IIntCallback.Stub() {
+                    override fun callback(result: Int) {
+                        // A callback running at all means the device did NOT power
+                        // down (a real reboot/shutdown takes the process first), so a
+                        // non-zero code is a rejection worth reporting. On 0 the
+                        // action was accepted and the device is on its way down.
+                        Log.i(TAG, "pbsControlSetDeviceAction result: $result for $action")
+                        if (result != 0) {
+                            sendPowerResult(
+                                resultType, "fail",
+                                "pbsControlSetDeviceAction returned $result"
+                            )
+                        }
+                    }
+                })
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to run $resultType", e)
+                sendPowerResult(resultType, "fail", e.message ?: "Unknown error")
+            }
+        }.start()
+    }
+
+    private fun sendPowerResult(resultType: String, status: String, error: String) {
+        val result = JSONObject().apply {
+            put("type", resultType)
+            put("status", status)
+            if (error.isNotEmpty()) {
+                put("error", error)
+            }
+        }
+        webSocketManager.sendMessage(result)
     }
 
     private fun executeInstall(payload: JSONObject) {

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -410,8 +410,12 @@ class MdmClientService : Service() {
      *
      * A PICO headset refuses a full power-off while a USB/charging cable is
      * connected unless the device-wide "power off with USB cable" setting is
-     * enabled. Venue devices are typically on charge, so the shutdown path
-     * enables it first (reboot is unaffected — it cycles regardless of charge).
+     * enabled. Venue devices are typically on charge, so shutdown treats that
+     * setting as a **precondition**: it is applied *before* the `accepted` ack,
+     * and if it cannot be applied the client reports `fail` and does not proceed
+     * — otherwise the console would show `accepted` while a cabled headset stays
+     * online. Reboot is unaffected (it cycles regardless of charge) and keeps the
+     * plain pre-ack model.
      */
     private fun executePowerControl(action: PBS_DeviceControlEnum, resultType: String) {
         Thread {
@@ -422,22 +426,29 @@ class MdmClientService : Service() {
                     sendPowerResult(resultType, "fail", "TobService not available")
                     return@Thread
                 }
-                // Acknowledge only once there is a binder to act on (so a missing binder
-                // reports a clean "fail", not "accepted" then "fail"), then give the ack a
-                // bounded chance to reach the wire before the reboot/shutdown takes the
-                // connection down — sendMessage only enqueues.
-                sendPowerResult(resultType, "accepted", "")
-                webSocketManager.awaitOutboundFlush(2_000)
+                // Shutdown precondition: allow power-off while charging BEFORE acking, so
+                // a failure to apply it reports "fail" rather than a misleading "accepted"
+                // on a cabled device that then stays online. The trailing int is the
+                // standard TobService ext/process arg (0); the call returns void, so a
+                // thrown RemoteException is the only failure signal.
                 if (action == PBS_DeviceControlEnum.DEVICE_CONTROL_SHUTDOWN) {
-                    // Without this the device stays on when powered off while charging.
-                    // The trailing int is the standard TobService ext/process arg (0).
                     try {
                         binder.pbsControlSetPowerOffwithUSBCable(PBS_SwitchEnum.S_ON, 0)
                         Log.i(TAG, "Enabled power-off-with-USB-cable before shutdown")
                     } catch (e: Throwable) {
-                        Log.w(TAG, "Failed to allow power-off while charging; shutdown may be blocked on a cabled device", e)
+                        Log.e(TAG, "Could not allow power-off while charging; aborting shutdown", e)
+                        sendPowerResult(
+                            resultType, "fail",
+                            "Could not enable power-off while charging: ${e.message ?: e.javaClass.simpleName}"
+                        )
+                        return@Thread
                     }
                 }
+                // Acknowledge (the precondition, if any, has now succeeded), then give the
+                // ack a bounded chance to reach the wire before the reboot/shutdown takes
+                // the connection down — sendMessage only enqueues.
+                sendPowerResult(resultType, "accepted", "")
+                webSocketManager.awaitOutboundFlush(2_000)
                 Log.i(TAG, "Invoking pbsControlSetDeviceAction: $action")
                 binder.pbsControlSetDeviceAction(action, object : IIntCallback.Stub() {
                     override fun callback(result: Int) {

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1440,6 +1440,8 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
 
                 elif msg_type in {
                     "LAUNCH_RESULT",
+                    "REBOOT_RESULT",
+                    "POWER_OFF_RESULT",
                     "INSTALL_RESULT",
                     "PUSH_FILES_RESULT",
                     "VERIFY_APK_RESULT",
@@ -1560,6 +1562,12 @@ async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
 
                 if msg_type == "LAUNCH_APP":
                     await handle_launch_app(ws, data)
+
+                elif msg_type == "REBOOT_DEVICE":
+                    await handle_reboot_device(ws, data)
+
+                elif msg_type == "POWER_OFF_DEVICE":
+                    await handle_power_off_device(ws, data)
 
                 elif msg_type == "INSTALL_APK":
                     await handle_install_apk(ws, data)
@@ -1955,6 +1963,74 @@ async def handle_launch_app(admin_ws: web.WebSocketResponse, data: dict):
     await admin_ws.send_str(json.dumps({
         "type": "LAUNCH_SENT",
         "package_name": package_name,
+        "sent_count": sent_count,
+        "target_count": len(target_ids),
+    }))
+
+
+async def handle_reboot_device(admin_ws: web.WebSocketResponse, data: dict):
+    """Process a REBOOT_DEVICE command from an admin and reboot target HMDs."""
+    await _dispatch_power_command(
+        admin_ws, data,
+        execute_type="EXECUTE_REBOOT",
+        sent_type="REBOOT_SENT",
+        label="REBOOT_DEVICE",
+    )
+
+
+async def handle_power_off_device(admin_ws: web.WebSocketResponse, data: dict):
+    """Process a POWER_OFF_DEVICE command from an admin and shut down target HMDs."""
+    await _dispatch_power_command(
+        admin_ws, data,
+        execute_type="EXECUTE_POWER_OFF",
+        sent_type="POWER_OFF_SENT",
+        label="POWER_OFF_DEVICE",
+    )
+
+
+async def _dispatch_power_command(
+    admin_ws: web.WebSocketResponse,
+    data: dict,
+    *,
+    execute_type: str,
+    sent_type: str,
+    label: str,
+):
+    """Fan a payload-less power command out to the resolved target device sockets.
+
+    Reboot and power-off carry no transfer and no per-device state, so this is
+    the un-throttled launch-style fan-out, not the queued install path. The
+    device acknowledges receipt with a ``*_RESULT: accepted`` before it invokes
+    the SDK call — a successful reboot/shutdown tears the socket down before any
+    success frame could flush, so the real success signal is the device going
+    offline (and, for reboot, reconnecting), tracked by the connection status.
+    """
+    target_devices: list[str] = data.get("target_devices", [])
+    target_ids = resolve_target_ids(target_devices)
+
+    if not target_ids:
+        await admin_ws.send_str(json.dumps({
+            "type": "ERROR",
+            "message": "No matching online devices found",
+        }))
+        return
+
+    execute_msg = json.dumps({"type": execute_type})
+
+    sent_count = 0
+    for did in target_ids:
+        entry = devices.get(did)
+        if entry:
+            try:
+                await entry["ws"].send_str(execute_msg)
+                sent_count += 1
+            except ConnectionResetError:
+                log.warning("Failed to send %s to %s (disconnected)", execute_type, did)
+
+    log.info("%s: sent to %d/%d devices", label, sent_count, len(target_ids))
+
+    await admin_ws.send_str(json.dumps({
+        "type": sent_type,
         "sent_count": sent_count,
         "target_count": len(target_ids),
     }))

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -500,6 +500,18 @@
               </div>
             </div>
             <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="power">
+              <div class="cmd-head" data-act="toggleCmd"><span>Power Control</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <div class="push-warn">⚠ Reboot or power off the selected devices — whatever is running is interrupted. Power off works <strong>even while charging</strong>, and a powered-off headset stays off and <strong>cannot be turned back on remotely</strong> — it must be woken physically. Success shows as the device dropping offline (a reboot reconnects on its own after ~30–60s).</div>
+                <label class="push-confirm"><input type="checkbox" id="powerConfirm"> I understand the selected devices will be interrupted</label>
+                <div class="btn-row">
+                  <button class="btn btn-danger-outline" id="btnReboot" disabled>Reboot Selected</button>
+                  <button class="btn btn-danger-outline" id="btnPowerOff" disabled>Power Off Selected</button>
+                </div>
+              </div>
+            </div>
+            <div class="cmd-divider"></div>
             <div class="cmd-section collapsed" data-cmd="retire">
               <div class="cmd-head" data-act="toggleCmd"><span>Retire Devices</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
@@ -617,6 +629,9 @@
       const verifyDirJson = document.getElementById('verifyDirJson');
       const verifyDirRefName = document.getElementById('verifyDirRefName');
       const btnVerifyDir = document.getElementById('btnVerifyDir');
+      const powerConfirm = document.getElementById('powerConfirm');
+      const btnReboot = document.getElementById('btnReboot');
+      const btnPowerOff = document.getElementById('btnPowerOff');
       const retireConfirm = document.getElementById('retireConfirm');
       const btnRetire = document.getElementById('btnRetire');
       const logContainer = document.getElementById('logContainer');
@@ -853,6 +868,10 @@
             break;
           }
           case 'LAUNCH_SENT': addLog('Launch command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
+          case 'REBOOT_SENT': addLog('Reboot command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
+          case 'POWER_OFF_SENT': addLog('Power-off command sent to ' + msg.sent_count + '/' + msg.target_count + ' device(s)', 'info'); break;
+          case 'REBOOT_RESULT': logPowerResult('Reboot', msg); break;
+          case 'POWER_OFF_RESULT': logPowerResult('Power off', msg); break;
           case 'INSTALL_SENT': addLog('Install job queued for ' + msg.target_count + ' device(s)' + (msg.max_concurrent ? ' (max ' + msg.max_concurrent + ' concurrent transfer(s))' : ''), 'info'); break;
           case 'INSTALL_PROGRESS': showTransferProgress('install', msg); break;
           case 'INSTALL_DEVICE_STATE': {
@@ -1264,6 +1283,8 @@
         syncPanel.refreshButton(has);
         btnVerifyApk.disabled = !verifyApkRef || verifyApkPkg.value.trim() === '' || !has;
         btnVerifyDir.disabled = !verifyDirRef || verifyDirPath.value.trim() === '' || !has;
+        btnReboot.disabled = !powerConfirm.checked || !has;
+        btnPowerOff.disabled = !powerConfirm.checked || !has;
         btnRetire.disabled = !retireConfirm.checked || !has;
       }
 
@@ -1503,6 +1524,40 @@
           addLog('Retiring ' + online.length + ' device(s)…', 'info');
           retireConfirm.checked = false;
           updateButtons();
+        }
+      }
+
+      // Reboot / power off share one confirm gate. A successful reboot/shutdown
+      // kills the device's socket before any success frame arrives, so the outcome
+      // is read from the connection status (offline = done), not a RESULT here.
+      function sendPower(kind) {
+        if (!powerConfirm.checked) return;
+        const isReboot = kind === 'reboot';
+        const verb = isReboot ? 'Reboot' : 'Power off';
+        const type = isReboot ? 'REBOOT_DEVICE' : 'POWER_OFF_DEVICE';
+        const online = onlineTargets(Array.from(selectedIds));
+        if (!online.length) { addLog('No online devices selected to ' + verb.toLowerCase(), 'warn'); return; }
+        const names = online.map(labelFor).join(', ');
+        const extra = isReboot
+          ? 'These devices will restart and reconnect on their own.'
+          : 'These devices will power off and CANNOT be turned back on remotely.';
+        if (!confirm(verb + ' ' + online.length + ' device(s)?\n' + names + '\n\n' + extra)) return;
+        if (wsSend({ type: type, target_devices: online }, verb.toLowerCase() + ' devices')) {
+          addLog(verb + ' command sent to ' + online.length + ' device(s)…', 'info');
+          powerConfirm.checked = false;
+          updateButtons();
+        }
+      }
+
+      // 'accepted' = the device got the command and is going down (confirm via it
+      // dropping offline); 'fail' = the SDK rejected it and the device stayed up.
+      // A 'success' status is never expected — the reboot takes the socket first.
+      function logPowerResult(verb, msg) {
+        if (msg.status === 'accepted') {
+          addLog('[OK] ' + verb + ' accepted on ' + labelFor(msg.device_id) + ' — watch for it to go offline', 'success');
+        } else {
+          const detail = msg.error || msg.message || '';
+          addLog('[FAIL] ' + verb + ' on ' + labelFor(msg.device_id) + (detail ? ' - ' + detail : ''), 'fail');
         }
       }
 
@@ -2289,6 +2344,9 @@
       verifyDirJson.addEventListener('change', onVerifyDirJson);
       verifyDirPath.addEventListener('input', updateButtons);
       btnVerifyDir.addEventListener('click', sendVerifyDir);
+      powerConfirm.addEventListener('change', updateButtons);
+      btnReboot.addEventListener('click', function () { sendPower('reboot'); });
+      btnPowerOff.addEventListener('click', function () { sendPower('power_off'); });
       retireConfirm.addEventListener('change', updateButtons);
       btnRetire.addEventListener('click', sendRetire);
       btnClearLog.addEventListener('click', function () { logContainer.innerHTML = ''; logContainer.appendChild(logEmpty); logEmpty.style.display = 'block'; });

--- a/mdm-server/tests/test_power_control.py
+++ b/mdm-server/tests/test_power_control.py
@@ -1,0 +1,209 @@
+"""Tests for remote power control — reboot / power off (issue #74).
+
+REBOOT_DEVICE / POWER_OFF_DEVICE fan out to online target sockets exactly like
+LAUNCH_APP (un-throttled, payload-less EXECUTE_* frames) and ack the admin with
+a *_SENT count. Unlike a launch there is no meaningful success RESULT: a
+successful reboot/shutdown tears the socket down first, so the client's
+*_RESULT: accepted / fail is only an acknowledgement, and the real success
+signal is the device dropping offline. These tests pin the server-side fan-out
+and dispatch shape with the same FakeWS harness test_retire.py uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import aiohttp
+import pytest
+from aiohttp.test_utils import TestServer
+
+from styly_mdm import server
+
+
+class FakeWS:
+    """Minimal stand-in for a WebSocketResponse that records sent frames."""
+
+    def __init__(self):
+        self.sent: list[str] = []
+
+    async def send_str(self, s: str) -> None:
+        self.sent.append(s)
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    collections = (
+        server.devices, server.admin_connections, server.pending_transfers,
+        server._transfer_tasks, server.pending_self_updates, server.pending_retires,
+        server._apk_hash_cache, server.device_registry, server.device_groups,
+    )
+    for coll in collections:
+        coll.clear()
+    server.reset_transfer_slots()
+    yield
+    for coll in collections:
+        coll.clear()
+    server.reset_transfer_slots()
+
+
+def add_device(device_id: str) -> FakeWS:
+    ws = FakeWS()
+    server.devices[device_id] = {
+        "ws": ws, "device_id": device_id, "model": "M", "ip": "1.1.1.1",
+        "status": "online", "startup_app": None, "battery": None,
+        "version_code": 8, "version_name": "0.4.0",
+    }
+    return ws
+
+
+def add_admin() -> FakeWS:
+    ws = FakeWS()
+    server.admin_connections.add(ws)
+    return ws
+
+
+def frames_of(ws: FakeWS, msg_type: str) -> list[dict]:
+    return [json.loads(m) for m in ws.sent if json.loads(m).get("type") == msg_type]
+
+
+# ---------------------------------------------------------------------------
+# Fan-out — reboot
+# ---------------------------------------------------------------------------
+
+def test_reboot_fans_out_payloadless_execute_and_acks():
+    async def body():
+        admin = add_admin()
+        d0 = add_device("dev0")
+        d1 = add_device("dev1")
+
+        await server.handle_reboot_device(admin, {"target_devices": ["dev0", "dev1"]})
+
+        # Each target gets exactly one payload-less EXECUTE_REBOOT.
+        assert frames_of(d0, "EXECUTE_REBOOT") == [{"type": "EXECUTE_REBOOT"}]
+        assert frames_of(d1, "EXECUTE_REBOOT") == [{"type": "EXECUTE_REBOOT"}]
+        # The admin is acked with the dispatch counts.
+        assert frames_of(admin, "REBOOT_SENT") == [
+            {"type": "REBOOT_SENT", "sent_count": 2, "target_count": 2}
+        ]
+
+    asyncio.run(body())
+
+
+def test_power_off_fans_out_payloadless_execute_and_acks():
+    async def body():
+        admin = add_admin()
+        d0 = add_device("dev0")
+
+        await server.handle_power_off_device(admin, {"target_devices": ["dev0"]})
+
+        assert frames_of(d0, "EXECUTE_POWER_OFF") == [{"type": "EXECUTE_POWER_OFF"}]
+        assert frames_of(admin, "POWER_OFF_SENT") == [
+            {"type": "POWER_OFF_SENT", "sent_count": 1, "target_count": 1}
+        ]
+
+    asyncio.run(body())
+
+
+def test_power_wildcard_targets_all_online_devices():
+    async def body():
+        admin = add_admin()
+        d0 = add_device("dev0")
+        d1 = add_device("dev1")
+
+        await server.handle_reboot_device(admin, {"target_devices": ["*"]})
+
+        assert frames_of(d0, "EXECUTE_REBOOT")
+        assert frames_of(d1, "EXECUTE_REBOOT")
+        assert frames_of(admin, "REBOOT_SENT")[0]["target_count"] == 2
+
+    asyncio.run(body())
+
+
+def test_power_off_with_no_matching_devices_errors_and_dispatches_nothing():
+    async def body():
+        admin = add_admin()
+        # No devices registered at all: nothing to power off.
+        await server.handle_power_off_device(admin, {"target_devices": ["ghost"]})
+
+        errors = frames_of(admin, "ERROR")
+        assert errors and "No matching online devices" in errors[0]["message"]
+        assert not frames_of(admin, "POWER_OFF_SENT")
+
+    asyncio.run(body())
+
+
+def test_power_off_skips_unknown_ids_but_dispatches_known_ones():
+    async def body():
+        admin = add_admin()
+        d0 = add_device("dev0")
+
+        await server.handle_power_off_device(
+            admin, {"target_devices": ["dev0", "does-not-exist"]}
+        )
+
+        assert frames_of(d0, "EXECUTE_POWER_OFF") == [{"type": "EXECUTE_POWER_OFF"}]
+        sent = frames_of(admin, "POWER_OFF_SENT")[0]
+        assert sent["sent_count"] == 1 and sent["target_count"] == 1
+
+    asyncio.run(body())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — the device's *_RESULT is forwarded to admins, device_id-stamped
+# ---------------------------------------------------------------------------
+
+async def _recv_type(ws, msg_type: str, timeout: float = 2.0) -> dict | None:
+    try:
+        while True:
+            msg = await asyncio.wait_for(ws.receive(), timeout)
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(msg.data)
+                if data.get("type") == msg_type:
+                    return data
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING,
+                              aiohttp.WSMsgType.ERROR):
+                return None
+    except asyncio.TimeoutError:
+        return None
+
+
+async def _register(session, base: str, device_id: str):
+    ws = await session.ws_connect(base + "/ws/device")
+    await ws.send_json({
+        "type": "REGISTER", "device_id": device_id, "model": "M",
+        "ip": "1.1.1.2", "version_code": 8, "version_name": "0.4.0",
+    })
+    return ws
+
+
+def test_e2e_reboot_result_is_forwarded_to_admin_stamped(tmp_path):
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        ts = TestServer(server.create_app())
+        await ts.start_server()
+        base = f"http://{ts.host}:{ts.port}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                d0 = await _register(session, base, "dev0")
+                admin = await session.ws_connect(base + "/ws/admin")
+                assert await _recv_type(admin, "DEVICE_LIST") is not None
+
+                await admin.send_json({"type": "REBOOT_DEVICE", "target_devices": ["dev0"]})
+                assert (await _recv_type(admin, "REBOOT_SENT"))["sent_count"] == 1
+                assert await _recv_type(d0, "EXECUTE_REBOOT") is not None
+
+                # The client acks receipt before it invokes the SDK call; the server
+                # must forward it to admins with the device_id stamped on.
+                await d0.send_json({"type": "REBOOT_RESULT", "status": "accepted"})
+                fwd = await _recv_type(admin, "REBOOT_RESULT")
+                assert fwd is not None
+                assert fwd["status"] == "accepted"
+                assert fwd["device_id"] == "dev0"
+
+                await d0.close()
+                await admin.close()
+        finally:
+            await ts.close()
+
+    asyncio.run(body())


### PR DESCRIPTION
Closes #74.

## What

Remote **Reboot** and **Power Off** as a console fan-out action, mirroring `LAUNCH_APP`.

- **Server** (`server.py`): `REBOOT_DEVICE` / `POWER_OFF_DEVICE` admin requests → one `_dispatch_power_command` helper resolves targets and fans out payload-less `EXECUTE_REBOOT` / `EXECUTE_POWER_OFF` (un-throttled, launch-style), acking `REBOOT_SENT` / `POWER_OFF_SENT`. `REBOOT_RESULT` / `POWER_OFF_RESULT` added to the device→admin forward set.
- **Client** (`MdmClientService.kt`): `executePowerControl` calls `pbsControlSetDeviceAction(DEVICE_CONTROL_REBOOT | SHUTDOWN)` on the same uncast `IToBService` binder the silent-install path uses. No new manifest permission or SDK — `pico_advance_interface` is already declared.
- **Console** (`index.html`): one **Power Control** section (Reboot + Power Off) behind a shared confirmation checkbox + per-action `confirm()` dialog, mirroring Retire.
- **Docs** (`DEVELOPMENT.md`): protocol rows in all four tables + a "Remote Power Control" section.

## Outcome model

A successful reboot/shutdown tears down the socket before any `*_RESULT: success` could flush, so the client sends `*_RESULT: accepted` **before** invoking the SDK call and the real success signal is the **device dropping offline** (a reboot reconnects on its own after ~30–60s). `*_RESULT: fail` is only emitted when the SDK rejects the call (device stays up to report it).

## Power off while charging

Device testing surfaced that a PICO headset **refuses a full power-off while a USB/charging cable is connected** unless the device-wide setting is enabled — so the shutdown path calls `pbsControlSetPowerOffwithUSBCable(S_ON)` first. This is a **persistent, device-wide** setting: a cabled headset on a dock can be remotely powered off and then **stranded until it is physically woken** — the intended venue capability, gated behind the console confirmation. Reboot is unaffected (it cycles regardless of charge).

## Verification

- `222 passed` full `mdm-server` suite, incl. 6 new `test_power_control.py` (fan-out shape, `["*"]` wildcard, no-online → ERROR, unknown-id skip, and an E2E asserting `REBOOT_RESULT` is forwarded to admins `device_id`-stamped).
- `:app:compileDevDebugKotlin` clean — proves `pbsControlSetDeviceAction` and `pbsControlSetPowerOffwithUSBCable` resolve on `tobservicelib:4.3.16`.
- Console: `node --check` + a node harness against the real extracted `sendPower` / `logPowerResult`.
- **On device:** reboot verified; power off verified to require the USB-cable enable (this PR) for cabled devices — re-test after client redeploy.

No version bump here — that is a release-time `chore:` commit via `release-version-bump.yml`. At release this warrants a **MINOR** bump (0.4.0 → 0.5.0): both server and client changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)