### PR TITLE
docs: note the server version is frozen at install time

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Or run from a clone (for development):
 
 ```bash
 cd mdm-server
-pip install -e .
-python -m styly_mdm      # or ./run.sh
+uv sync                  # editable install into .venv
+uv run python -m styly_mdm   # or ./run.sh
 ```
 
 The server starts on port 7070 and displays its LAN IP addresses and the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1101,14 +1101,33 @@ discovery.
 
 ```bash
 cd mdm-server
-pip install -e '.[dev]'
-python -m pytest        # smoke tests
-python -m build         # sdist + wheel into dist/  (pip install build first)
+uv sync --extra dev     # editable install + pytest (plain `uv sync` drops the dev extra)
+uv run pytest           # smoke tests
+uv build                # sdist + wheel into dist/
 ```
 
 **Versioning.** The package version is derived from the `vX.Y.Z` git tag via
 `setuptools-scm` — the same tag the APK release flow uses, so server and APK share one
 version. There is no hardcoded version to bump.
+
+> **The version is frozen at install time, not at run time.** `styly_mdm.__version__`
+> reads `importlib.metadata.version("styly-mdm")`, so the value setuptools-scm computes is
+> baked into the installed package's metadata when you install it. A new tag or a plain
+> `git pull` does **not** change what an already-installed server reports (and the console
+> shows the server's version via `SERVER_INFO`) — you have to reinstall. Worse, `run.sh`
+> runs from `mdm-server/`, which puts that directory on `sys.path[0]`, so a stale
+> `mdm-server/styly_mdm.egg-info/` there **shadows every venv's dist-info** — recreating
+> the venv alone will not help. After any version bump, force a clean recompute:
+>
+> ```bash
+> cd mdm-server && rm -rf styly_mdm.egg-info && uv sync --extra dev
+> ```
+>
+> Verify with `uv run python -c "from styly_mdm import __version__; print(__version__)"`.
+> A server left behind shows up in the console as the top-bar version turning **red** — but
+> only once a client on a newer `major.minor` is actually `online` (offline / `updating` /
+> unknown-version devices never trigger it). Restart the running server afterwards, since
+> `__version__` is read once at import.
 
 **Release automation.** `.github/workflows/publish-pypi.yml` runs on the same
 `release: published` event as the APK build (`release.yml`): a human publishes the


### PR DESCRIPTION
## What

Documents a gotcha we hit on the dev server: the console kept showing the server as **v0.3.0** even though the repo was at tag `v0.4.0` and the fleet ran client `0.4.0-dev`. No code was stale — the version was just never reinstalled.

## Why

`styly_mdm.__version__` reads `importlib.metadata.version("styly-mdm")`, i.e. the value `setuptools-scm` bakes into the installed package's metadata **at install time**. A new `vX.Y.Z` tag or a plain `git pull` does not change what an already-installed server reports (the console shows it via `SERVER_INFO`). Worse, `run.sh` runs from `mdm-server/`, putting that directory on `sys.path[0]`, so a stale `mdm-server/styly_mdm.egg-info/` there **shadows every venv's dist-info** — recreating the venv alone doesn't help.

Symptom in the console: the top-bar server version turns **red** — but only once a client on a newer `major.minor` is actually `online` (`serverIsBehindAnyDevice()` skips offline / `updating` / unknown-version devices).

## Changes (docs only)

- **`docs/DEVELOPMENT.md`** — add a note under **Versioning** explaining the install-time freeze, the `egg-info` shadowing trap, the fix (`rm -rf styly_mdm.egg-info && uv sync --extra dev`), the verify command, and the "restart the server" reminder. Unify the Build & test block on `uv` (`uv sync --extra dev` / `uv run pytest` / `uv build`).
- **`README.md`** — align the clone-for-development quick start to `uv` (end-user PyPI `pip install` left as-is).

No behavior change; no diagrams affected.