### PR TITLE
feat: bulk "Update Selected" for the MDM client from the console

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -304,7 +304,7 @@ STYLY-MDM/
 | Message type | Description |
 |---|---|
 | `SERVER_INFO` | Server identity, sent once on connect (before the first `DEVICE_LIST`). Fields: `version` (the `styly_mdm` package version; the console renders it next to the `STYLY-MDM` brand in the top bar. Its `major.minor` is the compatibility reference — and the top-bar value itself turns red when a live client is on a *newer* `major.minor` (i.e. the server is the one lagging). See the compatibility note below). |
-| `CLIENT_APK_INFO` | The newest styly-mdm-client APK the server holds, sent on connect (right after `SERVER_INFO`, before `DEVICE_LIST`) and re-broadcast after every APK upload. Field: `apk` = `{filename, url, version}` or `null`. Drives the per-device **Update** button and the top-bar client-APK download link (see the notes below). |
+| `CLIENT_APK_INFO` | The newest styly-mdm-client APK the server holds, sent on connect (right after `SERVER_INFO`, before `DEVICE_LIST`) and re-broadcast after every APK upload. Field: `apk` = `{filename, url, version}` or `null`. Drives the per-device and bulk **Update** buttons and the top-bar client-APK download link (see the notes below). |
 | `DEVICE_LIST` | Current list of known devices. Fields: `devices` (array; each entry carries `status` (`online` / `offline` / `updating` — while a self-update's recovery is in flight — / `retiring` — announced a self-uninstall, awaiting the retire window — / `retired` — terminal, persisted after a successful retire), `version_code` / `version_name` (the client build, when known — the console renders it as a right-aligned badge per row, or `unknown` for clients that predate version reporting; a *stable-online* client whose `version_name` trails the server on `major.minor` is flagged red as needing an update — the reverse case, a client *ahead* of the server, reddens the top-bar server version instead. `updating` and offline rows are exempt, and the check is skipped only when the server version is the `0.0.0` untagged/not-installed fallback), and may include optional `battery`: `{level, charging, last_seen}`) |
 | `LAUNCH_SENT` | Confirmation that commands were dispatched. Fields: `package_name`, `sent_count`, `target_count` |
 | `REBOOT_SENT` / `POWER_OFF_SENT` | Confirmation that reboot/power-off commands were dispatched. Fields: `sent_count`, `target_count` |
@@ -361,6 +361,20 @@ STYLY-MDM/
 > package-data glob); an **sdist** source build does not (setuptools-scm only packs
 > git-tracked files), but `pip`/`uvx` install the wheel — so a released server ships
 > with its matching client, while a from-source run relies on an operator upload.
+
+> **Bulk client update (Update Selected).** The **Update MDM Client** command section
+> extends the per-device Update button to the whole selection. It targets exactly the
+> selected devices that are online *and* behind the server on `major.minor` — the same
+> `canUpdateDevice` gate the per-row button uses — skipping the already-current,
+> offline, and unknown-version ones. The button label carries the live count,
+> **Update Selected (N)**, and is disabled when none of the selection is behind (e.g.
+> the server holds no client APK on its own `major.minor`), so an operator can filter to
+> *Online*, select all, and update a fleet in one click. It emits a single `INSTALL_APK`
+> carrying every target device id — the same batched path `Install to Selected` uses,
+> which the server throttles (`_run_install_job`) — and writes the skipped count to the
+> activity log, so the gap between *selected* and *updated* is explicit. Because it
+> reuses the existing `INSTALL_APK` message and install job, no new component or message
+> type is introduced (the architecture / message-flow diagrams are unchanged).
 
 > **Downloading the client APK from the console.** The same APK that drives the
 > per-device **Update** button is also offered to the operator directly: when

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -417,6 +417,14 @@
               </div>
             </div>
             <div class="cmd-divider"></div>
+            <div class="cmd-section collapsed" data-cmd="updateClient">
+              <div class="cmd-head" data-act="toggleCmd"><span>Update MDM Client</span><span class="cmd-chevron">▾</span></div>
+              <div class="cmd-body">
+                <div class="push-note">Reinstalls the server's own MDM client APK on every selected device that is <strong>online and behind</strong> the server version — each reinstalls the client and restarts. Devices already current, offline, or of unknown version are skipped; the button shows how many will actually update. Needs a server client APK on the same major.minor as the server (the same one the per-device Update button uses).</div>
+                <button class="btn btn-success" id="btnUpdateClients" disabled>Update Selected</button>
+              </div>
+            </div>
+            <div class="cmd-divider"></div>
             <div class="cmd-section collapsed" data-cmd="push">
               <div class="cmd-head" data-act="toggleCmd"><span>Push Files</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
@@ -612,6 +620,7 @@
       const apkFile = document.getElementById('apkFile');
       const apkName = document.getElementById('apkName');
       const btnInstall = document.getElementById('btnInstall');
+      const btnUpdateClients = document.getElementById('btnUpdateClients');
       const launchPkg = document.getElementById('launchPkg');
       const launchExtra = document.getElementById('launchExtra');
       const btnLaunch = document.getElementById('btnLaunch');
@@ -1089,6 +1098,26 @@
         return list.map(deviceRowHtml).join('');
       }
 
+      // A stable-online client whose major.minor trails the server needs updating. Shared by
+      // the per-row version badge and the bulk "Update Selected" target filter so both agree
+      // on which devices are behind (an offline or `updating` device is never behind here).
+      function deviceVerBehind(d) {
+        if (!d) return false;
+        const srvMinor = serverMajorMinor();
+        const devMinor = parseMajorMinor(d.version_name);
+        return !!(srvMinor && devMinor && d.status === 'online' && cmpMajorMinor(devMinor, srvMinor) < 0);
+      }
+      // A one-click self-update is only offered when the server's client APK is on the *same*
+      // major.minor as the server — installing it brings a behind device exactly in sync. A
+      // stale APK (older than the server) would leave it still red; one ahead would push it past
+      // the server (flipping the top-bar red), which violates the lockstep policy. Neither is
+      // offered. Mirrors the per-row Update gate so the bulk button targets exactly the rows
+      // that show an individual button.
+      function canUpdateDevice(d) {
+        if (!deviceVerBehind(d)) return false;
+        return !!(clientApk && cmpMajorMinor(parseMajorMinor(clientApk.version), serverMajorMinor()) === 0);
+      }
+
       function deviceRowHtml(d) {
         const id = getDeviceId(d);
         const checked = selectedIds.has(id);
@@ -1107,21 +1136,13 @@
           // A stable-online client whose major.minor trails the server needs updating,
           // so its badge is flagged red. A client *ahead* of the server is the server's
           // problem, not the device's — that reddens the top-bar version instead.
-          const srvMinor = serverMajorMinor();
-          const devMinor = parseMajorMinor(d.version_name);
-          const verBehind = srvMinor && devMinor && d.status === 'online' && cmpMajorMinor(devMinor, srvMinor) < 0;
+          const verBehind = deviceVerBehind(d);
           const verBadge = d.version_name
             ? '<span class="dev-version' + (verBehind ? ' mismatch' : '') + '" title="' +
                 (verBehind ? 'Client v' + esc(d.version_name) + ' trails server ' + esc(serverVersion) + ' — needs updating' : 'Client build') +
                 '">v' + esc(d.version_name) + '</span>'
             : '<span class="dev-version unknown" title="Client build unknown (device predates version reporting)">unknown</span>';
-          // Offer a one-click self-update only when the server's client APK is on the
-          // *same* major.minor as the server — installing it brings this behind device
-          // exactly in sync. A stale APK (older than the server) would leave it still
-          // red; one ahead of the server would push it past the server (flipping the
-          // top-bar red), which violates the lockstep policy. Neither is offered.
-          const canUpdate = verBehind && clientApk &&
-            cmpMajorMinor(parseMajorMinor(clientApk.version), srvMinor) === 0;
+          const canUpdate = canUpdateDevice(d);
           const updateBtn = canUpdate
             ? '<button class="btn-update" data-act="update" data-id="' + esc(id) + '" title="Install styly-mdm-client v' + esc(clientApk.version) + ' (the device reinstalls the MDM client and restarts)">Update</button>'
             : '';
@@ -1286,6 +1307,12 @@
         btnReboot.disabled = !powerConfirm.checked || !has;
         btnPowerOff.disabled = !powerConfirm.checked || !has;
         btnRetire.disabled = !retireConfirm.checked || !has;
+        // Enabled only when at least one selected device is actually behind and updatable; the
+        // count tells the operator how many of the selection this one click will update.
+        let updatable = 0;
+        selectedIds.forEach(function (id) { if (canUpdateDevice(deviceById(id))) updatable++; });
+        btnUpdateClients.disabled = updatable === 0;
+        btnUpdateClients.textContent = updatable ? 'Update Selected (' + updatable + ')' : 'Update Selected';
       }
 
       // ---------------- Selection actions ----------------
@@ -1584,6 +1611,24 @@
         deviceTaskState[id] = { task: 'install', status: 'queued', filename: clientApk.filename, detail: '' };
         updateTaskCell(id);
         addLog('Updating ' + name + ' to client v' + clientApk.version, 'info');
+      }
+      // Bulk sibling of sendClientUpdate: fan the server's own client APK out to every selected
+      // device that is online and behind (canUpdateDevice), skipping already-current, offline,
+      // and unknown-version ones. The server throttles the actual fan-out (INSTALL_APK →
+      // _run_install_job), so one message carries the whole batch — 100 clicks become one.
+      function sendClientUpdateBulk() {
+        if (!clientApk) { addLog('No client APK available on the server to update with', 'warn'); return; }
+        const selected = Array.from(selectedIds);
+        const targets = selected.filter(function (id) { return canUpdateDevice(deviceById(id)); });
+        const skipped = selected.length - targets.length;
+        if (!targets.length) { addLog('No selected devices need a client update (already current or offline)', 'warn'); return; }
+        if (!confirm('Update ' + targets.length + ' device(s) to styly-mdm-client v' + clientApk.version + '?\n\nEach device will reinstall the MDM client and restart.')) return;
+        // Absolute URL against our own origin, exactly like an operator-uploaded APK.
+        const apkUrl = new URL(clientApk.url, location.origin).href;
+        if (!wsSend({ type: 'INSTALL_APK', target_devices: targets, apk_url: apkUrl, apk_filename: clientApk.filename }, 'update client')) return;
+        targets.forEach(function (id) { deviceTaskState[id] = { task: 'install', status: 'queued', filename: clientApk.filename, detail: '' }; updateTaskCell(id); });
+        addLog('Updating ' + targets.length + ' device(s) to client v' + clientApk.version +
+          (skipped ? ' · ' + skipped + ' selected skipped (already current or offline)' : ''), 'info');
       }
       function sendForget(id) {
         const d = deviceById(id); const name = (d && d.label) || id;
@@ -2328,6 +2373,7 @@
       launchPkg.addEventListener('input', updateButtons);
       startupPkg.addEventListener('input', updateButtons);
       btnInstall.addEventListener('click', sendInstall);
+      btnUpdateClients.addEventListener('click', sendClientUpdateBulk);
       btnLaunch.addEventListener('click', sendLaunch);
       btnStartupSet.addEventListener('click', sendSetStartup);
       btnStartupClear.addEventListener('click', sendClearStartup);


### PR DESCRIPTION
## What

Adds a bulk **Update Selected** action for the MDM client self-update, so an
operator can update many devices at once instead of clicking the per-row
**Update** button on each of, say, 100 devices.

Usage: filter the Devices list to **Online**, select all, then click
**Update MDM Client → Update Selected (N)** once.

## How

- The per-row version gate is lifted into two shared predicates —
  `deviceVerBehind(d)` and `canUpdateDevice(d)` — reused by the row version
  badge, the bulk target filter, and the button's count, so all three agree on
  exactly which devices are behind. The per-device Update button and the red
  mismatch badge are unchanged (byte-identical truthiness).
- `sendClientUpdateBulk()` filters the selection to the online, version-behind
  devices (skipping already-current / offline / unknown-version), confirms, and
  sends a single `INSTALL_APK` carrying the whole batch. The server throttles the
  actual fan-out (`_run_install_job`), so the batched transport is the same one
  `Install to Selected` already uses. Crux: `sendClientUpdate` / `INSTALL_APK`
  never re-check version (the gate lived only in row render), so the bulk send
  has to filter its own targets — otherwise it would push the client APK to
  already-current or ahead devices.
- The button label carries the live count **Update Selected (N)** and is disabled
  when nothing in the selection is updatable (e.g. the server holds no client APK
  on its own major.minor). The skipped count is written to the activity log so the
  gap between *selected* and *updated* is explicit.

**Console-only** change — no server or client code changes. No new message type or
component (reuses `INSTALL_APK` / `_run_install_job`), so the architecture /
message-flow diagrams are unchanged. No version bump (release-time chore per repo
convention).

## Verification

- Extracted inline-script syntax check (`new Function`) passes.
- Node harness against the **real functions sliced from `index.html`** — 34/34:
  the filter picks only the online-behind device (current / ahead / offline /
  unknown all excluded); the refactor is byte-identical in truthiness to the old
  inline gate across the version edge cases (`0.10.0`, `updating` status);
  `sendClientUpdateBulk` sends `target_devices` = exactly the updatable subset
  with an absolute URL and logs the skipped count; confirm-cancel, non-lockstep
  APK, and null APK all send nothing.
- **On device**: verified end-to-end against a real dev server (0.4.x) and a
  headset running a `0.3.0-dev` client — the device rendered behind, **Update
  Selected (N)** appeared, and the bulk action self-updated the device to
  `0.4.0-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
