### PR TITLE
Fix admin WebSocket disconnect after bundle uploads

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -243,6 +243,10 @@ STYLY-MDM/
 
 ## WebSocket Protocol Reference
 
+Transport note: `/ws/admin` intentionally does not negotiate per-message
+compression as a workaround for the Chrome-to-server reserved-bit failure
+documented in PR #82. `/ws/device` keeps compression enabled for device traffic.
+
 ### Device → Server
 
 | Message type | Description |

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1532,7 +1532,13 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
 # ---------------------------------------------------------------------------
 
 async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
-    ws = web.WebSocketResponse(heartbeat=30)
+    # Admin messages are small control JSON, so compression saves effectively
+    # nothing. More importantly, Chrome/aiohttp interoperability after a long
+    # concurrent HTTP upload can produce reserved-bit errors on the browser's
+    # next control frame, closing this otherwise healthy connection.
+    # Keep compression enabled for the device channel, where messages can be
+    # larger, but remove the extension from this browser-facing channel.
+    ws = web.WebSocketResponse(heartbeat=30, compress=False)
     await ws.prepare(request)
     admin_connections.add(ws)
     log.info("Admin console connected from %s", request.remote)

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1532,10 +1532,10 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
 # ---------------------------------------------------------------------------
 
 async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
+    # A compressed admin connection was observed closing with a reserved-bit
+    # protocol error on the first control frame after a long HTTP upload.
     # Admin messages are small control JSON, so compression saves effectively
-    # nothing. More importantly, Chrome/aiohttp interoperability after a long
-    # concurrent HTTP upload can produce reserved-bit errors on the browser's
-    # next control frame, closing this otherwise healthy connection.
+    # nothing on this channel.
     # Keep compression enabled for the device channel, where messages can be
     # larger, but remove the extension from this browser-facing channel.
     ws = web.WebSocketResponse(heartbeat=30, compress=False)

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -1532,8 +1532,11 @@ async def device_ws_handler(request: web.Request) -> web.WebSocketResponse:
 # ---------------------------------------------------------------------------
 
 async def admin_ws_handler(request: web.Request) -> web.WebSocketResponse:
-    # A compressed admin connection was observed closing with a reserved-bit
-    # protocol error on the first control frame after a long HTTP upload.
+    # On aiohttp 3.14.3, the server-side reader rejected Chrome's first PUSH_FILES
+    # text frame after a long upload with "Received frame with non-zero reserved
+    # bits". The failure was observed only on the inbound Chrome admin frame.
+    # The device channel receives compressed OkHttp frames through the same
+    # reader, so device-side immunity is unverified and remains under observation.
     # Admin messages are small control JSON, so compression saves effectively
     # nothing on this channel.
     # Keep compression enabled for the device channel, where messages can be

--- a/mdm-server/tests/test_admin_websocket.py
+++ b/mdm-server/tests/test_admin_websocket.py
@@ -1,7 +1,6 @@
 """Admin WebSocket transport tests."""
 
 import asyncio
-import json
 
 import aiohttp
 from aiohttp.test_utils import TestServer
@@ -25,59 +24,12 @@ def test_admin_websocket_does_not_negotiate_compression(tmp_path):
                 # workaround is deliberately scoped to browser admin traffic.
                 device = await session.ws_connect(base + "/ws/device", compress=15)
                 assert device.compress == 15
-                await device.send_json({
-                    "type": "REGISTER",
-                    "device_id": "test-device",
-                    "model": "test",
-                    "ip": "127.0.0.1",
-                })
-
-                async def wait_registered():
-                    while "test-device" not in server.devices:
-                        await asyncio.sleep(0)
-
-                await asyncio.wait_for(wait_registered(), timeout=2)
 
                 admin = await session.ws_connect(base + "/ws/admin", compress=15)
                 assert admin.compress == 0
 
-                # Drain the four snapshots sent when an admin connects.
-                for _ in range(4):
-                    msg = await admin.receive(timeout=2)
-                    assert msg.type == aiohttp.WSMsgType.TEXT
-
-                # Exercise the same browser-to-server command that followed a
-                # multi-gigabyte upload in the reported failure.
-                await admin.send_json({
-                    "type": "PUSH_FILES",
-                    "target_devices": ["test-device"],
-                    "bundle_url": base + "/bundles/test.zip",
-                    "bundle_filename": "test.zip",
-                    "dest_path": "/sdcard/test",
-                    "delete_extras": False,
-                })
-                ack = await admin.receive(timeout=2)
-                assert ack.type == aiohttp.WSMsgType.TEXT
-                assert json.loads(ack.data)["type"] == "PUSH_FILES_SENT"
-
-                command = await device.receive(timeout=2)
-                assert command.type == aiohttp.WSMsgType.TEXT
-                assert json.loads(command.data)["type"] == "EXECUTE_PUSH_FILES"
-                await device.send_json({
-                    "type": "DOWNLOAD_COMPLETE",
-                    "task": "push",
-                    "dest_path": "/sdcard/test",
-                })
-
-                while True:
-                    progress = await admin.receive(timeout=2)
-                    assert progress.type == aiohttp.WSMsgType.TEXT
-                    payload = json.loads(progress.data)
-                    if payload.get("type") == "PUSH_PROGRESS" and payload.get("done"):
-                        break
-
-                await device.close()
                 await admin.close()
+                await device.close()
         finally:
             await test_server.close()
             server.admin_connections.clear()

--- a/mdm-server/tests/test_admin_websocket.py
+++ b/mdm-server/tests/test_admin_websocket.py
@@ -1,0 +1,86 @@
+"""Admin WebSocket transport tests."""
+
+import asyncio
+import json
+
+import aiohttp
+from aiohttp.test_utils import TestServer
+
+from styly_mdm import server
+
+
+def test_admin_websocket_does_not_negotiate_compression(tmp_path):
+    """The browser control channel stays uncompressed while device behavior is unchanged."""
+
+    async def body():
+        server._apply_data_dir(str(tmp_path))
+        server.admin_connections.clear()
+        test_server = TestServer(server.create_app())
+        await test_server.start_server()
+        base = f"http://{test_server.host}:{test_server.port}"
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                # Compression remains available on the device channel; the
+                # workaround is deliberately scoped to browser admin traffic.
+                device = await session.ws_connect(base + "/ws/device", compress=15)
+                assert device.compress == 15
+                await device.send_json({
+                    "type": "REGISTER",
+                    "device_id": "test-device",
+                    "model": "test",
+                    "ip": "127.0.0.1",
+                })
+
+                async def wait_registered():
+                    while "test-device" not in server.devices:
+                        await asyncio.sleep(0)
+
+                await asyncio.wait_for(wait_registered(), timeout=2)
+
+                admin = await session.ws_connect(base + "/ws/admin", compress=15)
+                assert admin.compress == 0
+
+                # Drain the four snapshots sent when an admin connects.
+                for _ in range(4):
+                    msg = await admin.receive(timeout=2)
+                    assert msg.type == aiohttp.WSMsgType.TEXT
+
+                # Exercise the same browser-to-server command that followed a
+                # multi-gigabyte upload in the reported failure.
+                await admin.send_json({
+                    "type": "PUSH_FILES",
+                    "target_devices": ["test-device"],
+                    "bundle_url": base + "/bundles/test.zip",
+                    "bundle_filename": "test.zip",
+                    "dest_path": "/sdcard/test",
+                    "delete_extras": False,
+                })
+                ack = await admin.receive(timeout=2)
+                assert ack.type == aiohttp.WSMsgType.TEXT
+                assert json.loads(ack.data)["type"] == "PUSH_FILES_SENT"
+
+                command = await device.receive(timeout=2)
+                assert command.type == aiohttp.WSMsgType.TEXT
+                assert json.loads(command.data)["type"] == "EXECUTE_PUSH_FILES"
+                await device.send_json({
+                    "type": "DOWNLOAD_COMPLETE",
+                    "task": "push",
+                    "dest_path": "/sdcard/test",
+                })
+
+                while True:
+                    progress = await admin.receive(timeout=2)
+                    assert progress.type == aiohttp.WSMsgType.TEXT
+                    payload = json.loads(progress.data)
+                    if payload.get("type") == "PUSH_PROGRESS" and payload.get("done"):
+                        break
+
+                await device.close()
+                await admin.close()
+        finally:
+            await test_server.close()
+            server.admin_connections.clear()
+            server.devices.clear()
+
+    asyncio.run(body())


### PR DESCRIPTION
## Summary

- Disable WebSocket compression for the browser admin channel.
- Keep device WebSocket compression unchanged; device-side immunity is unverified.
- Add regression coverage for admin and device compression negotiation.
- Document the transport workaround.

## Why

The failure reproduced twice with 7 GB uploads on aiohttp 3.14.3. In both cases, after the upload completed, the server-side aiohttp reader rejected the first `PUSH_FILES` frame sent by Chrome on `/ws/admin` with `Received frame with non-zero reserved bits`.

This was observed on the inbound Chrome-to-server path. `/ws/device` uses the same reader for compressed frames sent by OkHttp, so it is not proven immune and remains under observation. Admin messages are small, so disabling compression only on `/ws/admin` avoids the observed failure with negligible overhead.

## Test

- `uv run --extra dev pytest` — 223 passed