### PR TITLE
fix(client): preserve PICO USB power-off setting

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -926,17 +926,12 @@ gated by the `pico_advance_interface` manifest flag the client already declares.
 permission and no SDK addition were needed; shipping the two command handlers is what
 requires a client update + redeploy.
 
-**Power off while charging.** A PICO headset refuses a full power-off while a USB/charging
-cable is connected unless the device-wide *"power off with USB cable"* setting is enabled —
-so a plain `DEVICE_CONTROL_SHUTDOWN` leaves a cabled (venue) device on. The shutdown path
-therefore calls `pbsControlSetPowerOffwithUSBCable(S_ON, 0)` as a **precondition** — before
-the `accepted` ack — so a cabled device actually powers off; if the setting cannot be applied
-the client reports `POWER_OFF_RESULT: fail` and does not proceed, rather than acking
-`accepted` on a device that would stay online. This is a persistent, device-wide setting and the
-trade-off is deliberate: a headset on a charging dock **can be remotely powered off and then
-stranded until it is physically woken** — which is exactly the intended venue capability, and
-why the console gates power-off behind a confirmation. Reboot does not touch this setting (it
-cycles regardless of charge state).
+**Power off while charging.** The shutdown path invokes
+`DEVICE_CONTROL_SHUTDOWN` without changing the PICO device-wide *"power off with USB cable"*
+setting. This prevents a remote power-off from modifying a persistent system setting. Whether
+a cabled headset can power off is therefore controlled by the device's existing PICO setting;
+if the SDK rejects the shutdown, the client reports `POWER_OFF_RESULT: fail`. Reboot does not
+touch this setting.
 
 **Outcome model — the success signal is the device going offline, not a RESULT.** A
 successful reboot/shutdown tears down the client process and the WebSocket before any

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -928,10 +928,11 @@ requires a client update + redeploy.
 
 **Power off while charging.** The shutdown path invokes
 `DEVICE_CONTROL_SHUTDOWN` without changing the PICO device-wide *"power off with USB cable"*
-setting. This prevents a remote power-off from modifying a persistent system setting. Whether
-a cabled headset can power off is therefore controlled by the device's existing PICO setting;
-if the SDK rejects the shutdown, the client reports `POWER_OFF_RESULT: fail`. Reboot does not
-touch this setting.
+setting. This prevents a remote power-off from modifying a persistent system setting. On tested
+PICO devices, whether a cabled headset can power off depends on the current PICO setting and
+device firmware; behavior may vary by model and PUI version. If the device remains online,
+check that setting. If the SDK rejects the shutdown, the client reports `POWER_OFF_RESULT: fail`.
+Reboot does not touch this setting.
 
 **Outcome model — the success signal is the device going offline, not a RESULT.** A
 successful reboot/shutdown tears down the client process and the WebSocket before any

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -18,7 +18,6 @@ import android.util.Log
 import com.pvr.tobservice.ToBServiceHelper
 import com.pvr.tobservice.enums.PBS_DeviceControlEnum
 import com.pvr.tobservice.enums.PBS_PackageControlEnum
-import com.pvr.tobservice.enums.PBS_SwitchEnum
 import com.pvr.tobservice.interfaces.IIntCallback
 import com.pvr.tobservice.interfaces.IToBServiceProxy
 import org.json.JSONArray
@@ -612,14 +611,6 @@ class MdmClientService : Service() {
      * reconnecting). A `*_RESULT: fail` is only ever observed when the SDK
      * rejects the call — the device stays up, so that frame does flush.
      *
-     * A PICO headset refuses a full power-off while a USB/charging cable is
-     * connected unless the device-wide "power off with USB cable" setting is
-     * enabled. Venue devices are typically on charge, so shutdown treats that
-     * setting as a **precondition**: it is applied *before* the `accepted` ack,
-     * and if it cannot be applied the client reports `fail` and does not proceed
-     * — otherwise the console would show `accepted` while a cabled headset stays
-     * online. Reboot is unaffected (it cycles regardless of charge) and keeps the
-     * plain pre-ack model.
      */
     private fun executePowerControl(action: PBS_DeviceControlEnum, resultType: String) {
         Thread {
@@ -630,27 +621,8 @@ class MdmClientService : Service() {
                     sendPowerResult(resultType, "fail", "TobService not available")
                     return@Thread
                 }
-                // Shutdown precondition: allow power-off while charging BEFORE acking, so
-                // a failure to apply it reports "fail" rather than a misleading "accepted"
-                // on a cabled device that then stays online. The trailing int is the
-                // standard TobService ext/process arg (0); the call returns void, so a
-                // thrown RemoteException is the only failure signal.
-                if (action == PBS_DeviceControlEnum.DEVICE_CONTROL_SHUTDOWN) {
-                    try {
-                        binder.pbsControlSetPowerOffwithUSBCable(PBS_SwitchEnum.S_ON, 0)
-                        Log.i(TAG, "Enabled power-off-with-USB-cable before shutdown")
-                    } catch (e: Throwable) {
-                        Log.e(TAG, "Could not allow power-off while charging; aborting shutdown", e)
-                        sendPowerResult(
-                            resultType, "fail",
-                            "Could not enable power-off while charging: ${e.message ?: e.javaClass.simpleName}"
-                        )
-                        return@Thread
-                    }
-                }
-                // Acknowledge (the precondition, if any, has now succeeded), then give the
-                // ack a bounded chance to reach the wire before the reboot/shutdown takes
-                // the connection down — sendMessage only enqueues.
+                // Acknowledge, then give the ack a bounded chance to reach the wire before
+                // the reboot/shutdown takes the connection down — sendMessage only enqueues.
                 sendPowerResult(resultType, "accepted", "")
                 webSocketManager.awaitOutboundFlush(2_000)
                 Log.i(TAG, "Invoking pbsControlSetDeviceAction: $action")

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -521,7 +521,7 @@
             <div class="cmd-section collapsed" data-cmd="power">
               <div class="cmd-head" data-act="toggleCmd"><span>Power Control</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
-                <div class="push-warn">⚠ Reboot or power off the selected devices — whatever is running is interrupted. Power off works <strong>even while charging</strong>, and a powered-off headset stays off and <strong>cannot be turned back on remotely</strong> — it must be woken physically. Success shows as the device dropping offline (a reboot reconnects on its own after ~30–60s).</div>
+                <div class="push-warn">⚠ Reboot or power off the selected devices — whatever is running is interrupted. Power off while charging depends on the PICO device setting, and a powered-off headset stays off and <strong>cannot be turned back on remotely</strong> — it must be woken physically. Success shows as the device dropping offline (a reboot reconnects on its own after ~30–60s).</div>
                 <label class="push-confirm"><input type="checkbox" id="powerConfirm"> I understand the selected devices will be interrupted</label>
                 <div class="btn-row">
                   <button class="btn btn-danger-outline" id="btnReboot" disabled>Reboot Selected</button>

--- a/mdm-server/styly_mdm/static/index.html
+++ b/mdm-server/styly_mdm/static/index.html
@@ -521,7 +521,7 @@
             <div class="cmd-section collapsed" data-cmd="power">
               <div class="cmd-head" data-act="toggleCmd"><span>Power Control</span><span class="cmd-chevron">▾</span></div>
               <div class="cmd-body">
-                <div class="push-warn">⚠ Reboot or power off the selected devices — whatever is running is interrupted. Power off while charging depends on the PICO device setting, and a powered-off headset stays off and <strong>cannot be turned back on remotely</strong> — it must be woken physically. Success shows as the device dropping offline (a reboot reconnects on its own after ~30–60s).</div>
+                <div class="push-warn">⚠ Reboot or power off the selected devices — whatever is running is interrupted. Power off while charging depends on the headset's current PICO setting and firmware; behavior may vary by model/PUI. If it remains online, check that setting. A powered-off headset stays off and <strong>cannot be turned back on remotely</strong> — it must be woken physically. Success shows as the device dropping offline (a reboot reconnects on its own after ~30–60s).</div>
                 <label class="push-confirm"><input type="checkbox" id="powerConfirm"> I understand the selected devices will be interrupted</label>
                 <div class="btn-row">
                   <button class="btn btn-danger-outline" id="btnReboot" disabled>Reboot Selected</button>


### PR DESCRIPTION
## Summary

- Stop enabling PICO's persistent "Power off when USB is disconnected" setting during remote Power Off.
- Keep the existing `DEVICE_CONTROL_SHUTDOWN` call.
- Update the UI warning and developer documentation to reflect that power-off while charging depends on the device's existing PICO setting.

## Root cause

The client unconditionally called `pbsControlSetPowerOffwithUSBCable(S_ON, 0)` before every remote shutdown. The setting is device-wide and persistent, so it remained enabled after power-off even when the headset was not connected to USB.

Fixes #103

## Validation

- `./gradlew :app:compileDevDebugKotlin`
- `./gradlew :app:testDevDebugUnitTest`
- `git diff --check`

Both Gradle checks passed. Physical PICO verification is still required, especially for shutdown while USB-connected.