### PR TITLE
Simplify manual WebSocket endpoint input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ Install the MDM client APK on the HMD (see the [Developer Guide](docs/DEVELOPMEN
 2. Choose the connection mode:
    - Tap **Use Auto-Discovery** to clear any manual override and previous discovery
      cache, then immediately start fresh discovery on the LAN.
-   - Or enter a manual URL such as `ws://<server-ip>:7070/ws/device`, then tap
-     **Save & Connect**. The client keeps this URL separate from discovery results
-     and retries only that URL throughout each connection window.
+   - Or enter a manual server address such as `<server-ip>:7070` or
+     `<server-name>:7070`, then tap
+     **Save & Connect**. The client adds `ws://` and `/ws/device` automatically,
+     keeps the endpoint separate from discovery results, and retries only that
+     endpoint throughout each connection window.
 
-> **Note:** On first launch with no manual URL, the client automatically attempts
+> **Note:** On first launch with no manual address, the client automatically attempts
 > server discovery before falling back to the last discovered or default URL.
 
 The MDM client connects to the server, registers the device (serial number, model, IP address), and runs as a foreground service in the background.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1045,6 +1045,12 @@ Settings and tap **Save & Connect**. **Use Auto-Discovery** removes both the man
 preference and the previous discovery cache, then restarts the service so a fresh discovery
 begins immediately. A successful discovery creates a new cache for later fallback.
 
+The manual Settings field accepts an IPv4 address or hostname with an explicit
+port, for example `192.168.1.100:7070` or `mdm.local:7070`. The client expands it
+to `ws://<address>:<port>/ws/device`; inputs containing a scheme or path are
+rejected. After a successful connection, the Settings screen and foreground
+notification show the target as `Connected (<address>:<port>)`.
+
 ### Connection tunables (`/sdcard/styly-mdm/config.json`)
 
 The window duration and retry interval have built-in defaults and can be overridden by

--- a/mdm-client/app/src/dev/res/values/strings.xml
+++ b/mdm-client/app/src/dev/res/values/strings.xml
@@ -5,5 +5,5 @@
          cannot be installed at the same time. -->
     <string name="app_name">STYLY-MDM Dev</string>
     <!-- Dev uses the dev ws port (7080) so the placeholder doesn't point at prod. -->
-    <string name="server_url_hint">ws://192.168.1.100:7080/ws/device</string>
+    <string name="server_url_hint">192.168.1.100:7080</string>
 </resources>

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/MdmClientService.kt
@@ -1842,7 +1842,7 @@ class MdmClientService : Service() {
 
     private fun handleStatusChanged(connected: Boolean, message: String) {
         Log.i(TAG, "Connection status: connected=$connected, message=$message")
-        updateNotification(if (connected) "Connected" else message)
+        updateNotification(message)
 
         // Broadcast status for SettingsActivity
         val intent = Intent(ACTION_STATUS_UPDATE).apply {

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/SettingsActivity.kt
@@ -64,7 +64,7 @@ class SettingsActivity : AppCompatActivity() {
         journalRefreshButton = findViewById(R.id.journal_refresh_button)
         journalClearButton = findViewById(R.id.journal_clear_button)
 
-        serverUrlInput.setText(WebSocketManager.getManualServerUrl(this).orEmpty())
+        serverUrlInput.setText(WebSocketManager.getManualServerAddress(this).orEmpty())
 
         saveButton.setOnClickListener {
             saveAndRestart()
@@ -117,14 +117,18 @@ class SettingsActivity : AppCompatActivity() {
         if (url.isEmpty()) {
             Toast.makeText(
                 this,
-                "Enter a manual URL or use Auto-Discovery",
+                "Enter a manual server address or use Auto-Discovery",
                 Toast.LENGTH_SHORT,
             ).show()
             return
         }
 
         if (!WebSocketManager.saveManualServerUrl(this, url)) {
-            Toast.makeText(this, "Enter a valid ws:// or wss:// URL", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this,
+                "Enter a valid server address such as 192.168.1.100:7070",
+                Toast.LENGTH_SHORT,
+            ).show()
             return
         }
 
@@ -187,7 +191,7 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun updateStatusDisplay(connected: Boolean, message: String) {
-        statusText.text = if (connected) "Connected" else message
+        statusText.text = if (connected && message.isEmpty()) "Connected" else message
         statusText.setTextColor(
             if (connected) 0xFF4CAF50.toInt() else 0xFFFF5722.toInt()
         )

--- a/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
+++ b/mdm-client/app/src/main/java/com/styly/mdmclient/WebSocketManager.kt
@@ -24,6 +24,7 @@ import org.json.JSONObject
 import java.io.File
 import java.net.Inet4Address
 import java.net.NetworkInterface
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 /**
@@ -52,6 +53,7 @@ class WebSocketManager(
         private const val PREF_SERVER_URL = "server_url"
         // Kept separate from PREF_SERVER_URL, which is only a discovery cache.
         private const val PREF_MANUAL_SERVER_URL = "manual_server_url_value"
+        private const val MANUAL_SERVER_PATH = "/ws/device"
         // Last-resort fallback used only when discovery fails and no URL is saved.
         // The port is flavor-aware (BuildConfig.DEFAULT_WS_PORT) so the dev build
         // never falls back to the production port and accidentally connects to a
@@ -67,8 +69,7 @@ class WebSocketManager(
         const val PREF_STARTUP_APP_EXTRA = "startup_app_extra"
 
         internal fun saveManualServerUrl(context: Context, url: String): Boolean {
-            val normalized = url.trim()
-            if (!isValidWsUrl(normalized)) return false
+            val normalized = normalizeManualServerUrl(url) ?: return false
             preferences(context)
                 .edit()
                 .putString(PREF_MANUAL_SERVER_URL, normalized)
@@ -87,7 +88,29 @@ class WebSocketManager(
         internal fun getManualServerUrl(context: Context): String? {
             return preferences(context)
                 .getString(PREF_MANUAL_SERVER_URL, null)
-                ?.takeIf(::isValidWsUrl)
+                ?.takeIf(::isCanonicalManualServerUrl)
+        }
+
+        internal fun getManualServerAddress(context: Context): String? {
+            return getManualServerUrl(context)?.let(::serverAddress)
+        }
+
+        internal fun normalizeManualServerUrl(input: String): String? {
+            val address = input.trim().lowercase(Locale.ROOT)
+            if (!isValidServerAddress(address)) return null
+            val candidate = "ws://$address$MANUAL_SERVER_PATH"
+            return candidate.takeIf(::isCanonicalManualServerUrl)
+        }
+
+        internal fun serverAddress(url: String): String {
+            val httpUrl = Request.Builder().url(url).build().url
+            val host = httpUrl.host
+            val formattedHost = if (host.contains(":") && !host.startsWith("[")) {
+                "[$host]"
+            } else {
+                host
+            }
+            return "$formattedHost:${httpUrl.port}"
         }
 
         private fun getCachedServerUrl(context: Context): String {
@@ -109,6 +132,60 @@ class WebSocketManager(
             } catch (_: IllegalArgumentException) {
                 false
             }
+        }
+
+        private fun isCanonicalManualServerUrl(url: String): Boolean {
+            if (!url.startsWith("ws://")) return false
+            return try {
+                val httpUrl = Request.Builder().url(url).build().url
+                if (httpUrl.encodedPath != MANUAL_SERVER_PATH ||
+                    httpUrl.encodedQuery != null ||
+                    httpUrl.encodedFragment != null
+                ) {
+                    return false
+                }
+                val address = "${httpUrl.host}:${httpUrl.port}"
+                isValidServerAddress(address) && url == "ws://$address$MANUAL_SERVER_PATH"
+            } catch (_: IllegalArgumentException) {
+                false
+            }
+        }
+
+        private fun isValidServerAddress(address: String): Boolean {
+            val parts = address.split(":")
+            if (parts.size != 2) return false
+
+            if (!isValidServerHost(parts[0])) return false
+
+            if (!isAsciiDigits(parts[1])) return false
+            val port = parts[1].toIntOrNull() ?: return false
+            return port in 1..65535
+        }
+
+        private fun isValidServerHost(host: String): Boolean {
+            if (host.isEmpty()) return false
+            if (host.all { it in '0'..'9' || it == '.' }) {
+                val octets = host.split(".")
+                return octets.size == 4 && octets.none(::isInvalidOctet)
+            }
+            if (host.length > 253) return false
+            return host.split(".").all { label ->
+                label.isNotEmpty() &&
+                    label.length <= 63 &&
+                    label.first().isLetterOrDigit() &&
+                    label.last().isLetterOrDigit() &&
+                    label.all { it.isLetterOrDigit() || it == '-' }
+            }
+        }
+
+        private fun isInvalidOctet(value: String): Boolean {
+            if (!isAsciiDigits(value)) return true
+            val octet = value.toIntOrNull() ?: return true
+            return octet !in 0..255
+        }
+
+        private fun isAsciiDigits(value: String): Boolean {
+            return value.isNotEmpty() && value.all { it in '0'..'9' }
         }
     }
 
@@ -287,7 +364,7 @@ class WebSocketManager(
                 reconnectHandler.post {
                     if (this@WebSocketManager.webSocket !== webSocket) return@post
                     dispatch(scheduler.onConnected())
-                    onStatusChanged(true, "Connected")
+                    onStatusChanged(true, "Connected (${serverAddress(url)})")
                     sendRegistration()
                     startBatteryTelemetry()
                 }

--- a/mdm-client/app/src/main/res/values/strings.xml
+++ b/mdm-client/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">STYLY-MDM Client</string>
-    <string name="server_url_label">Manual Server URL (optional)</string>
-    <string name="server_url_hint">ws://192.168.1.100:7070/ws/device</string>
+    <string name="server_url_label">Manual Server Address (optional)</string>
+    <string name="server_url_hint">192.168.1.100:7070</string>
     <string name="use_auto_discovery">Use Auto-Discovery</string>
     <string name="save_and_connect">Save &amp; Connect</string>
     <string name="connection_status_label">Connection Status</string>

--- a/mdm-client/app/src/test/java/com/styly/mdmclient/ServerEndpointTest.kt
+++ b/mdm-client/app/src/test/java/com/styly/mdmclient/ServerEndpointTest.kt
@@ -1,0 +1,64 @@
+package com.styly.mdmclient
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ServerEndpointTest {
+
+    @Test
+    fun addressIsExpandedToDeviceWebSocketUrl() {
+        assertEquals(
+            "ws://192.168.1.42:7080/ws/device",
+            WebSocketManager.normalizeManualServerUrl(" 192.168.1.42:7080 "),
+        )
+    }
+
+    @Test
+    fun hostnameIsExpandedToDeviceWebSocketUrl() {
+        assertEquals(
+            "ws://mdm.local:7080/ws/device",
+            WebSocketManager.normalizeManualServerUrl("mdm.local:7080"),
+        )
+    }
+
+    @Test
+    fun hostnameIsNormalizedToLowercase() {
+        assertEquals(
+            "ws://mdm.local:7080/ws/device",
+            WebSocketManager.normalizeManualServerUrl("MDM.local:7080"),
+        )
+    }
+
+    @Test
+    fun portIsRequiredForAddressInput() {
+        assertNull(WebSocketManager.normalizeManualServerUrl("192.168.1.42"))
+    }
+
+    @Test
+    fun pathAndSchemeAreRejectedForAddressInput() {
+        assertNull(
+            WebSocketManager.normalizeManualServerUrl("192.168.1.42:7080/ws/device"),
+        )
+        assertNull(
+            WebSocketManager.normalizeManualServerUrl("ws://192.168.1.42:7080/ws/device"),
+        )
+        assertNull(
+            WebSocketManager.normalizeManualServerUrl("wss://192.168.1.42:7080/ws/device"),
+        )
+    }
+
+    @Test
+    fun malformedAddressPartsAreRejected() {
+        assertNull(WebSocketManager.normalizeManualServerUrl("192.168.1.+5:7080"))
+        assertNull(WebSocketManager.normalizeManualServerUrl("192.168.1.42:+7080"))
+    }
+
+    @Test
+    fun serverAddressOmitsSchemeAndPath() {
+        assertEquals(
+            "192.168.1.42:7080",
+            WebSocketManager.serverAddress("ws://192.168.1.42:7080/ws/device"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Accept an IPv4 address or hostname with an explicit port for manual server input.
- Build `ws://host:port/ws/device` internally and reject schemes or custom paths.
- Show `Connected (host:port)` in the Settings screen and foreground notification.
- Update documentation, hints, and focused endpoint validation tests.

## Why

The manual connection field previously required users to enter the full WebSocket URL, including the scheme and device path. The client now exposes only the server address while keeping the endpoint format fixed and predictable.

## Validation

- `./gradlew :app:testDevDebugUnitTest :app:testProdDebugUnitTest`
- `git diff --check`

The left image shows the old version, and the right image shows the new version.
<img width="2000" height="667" alt="image" src="https://github.com/user-attachments/assets/45e39053-55ac-44a6-9310-1bfe82013259" />
