### PR TITLE
fix(server): advertise the interface facing the discovery requester

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1111,6 +1111,23 @@ Manual mode retries only the configured WebSocket URL and sends no discovery bro
 > port 7081 (discovery) and 7080 (WebSocket) instead — see
 > [Running a Dev Environment Alongside Production](#running-a-dev-environment-alongside-production).
 
+### Which address the server advertises
+
+A server machine rarely has one "own" IP: a laptop carries Wi-Fi plus an unplugged
+Ethernet port holding a self-assigned `169.254.x.x`, and a Windows host sharing its
+connection (ICS) carries `192.168.137.1` alongside its uplink NIC. The address a device
+must connect to therefore depends on **which network that device broadcast from**.
+
+So `ws_url` is resolved per request, not at startup. `source_ip_for()` opens a connected
+UDP socket toward the requester — `connect()` consults the routing table without sending
+a packet — and reports the local address on the interface facing them. Only if that
+lookup fails does the server fall back to the first entry of the startup-time
+`get_local_ip_addresses()` list.
+
+That list drops link-local (`169.254.0.0/16`) addresses as well as loopback. Link-local
+addresses are self-assigned to interfaces that failed DHCP, so they are never reachable
+from a device on the real LAN; advertising one strands every client that believes it.
+
 ### Startup duplicate-server guard
 
 Because the client takes the **first** discovery response it receives, two

--- a/mdm-server/styly_mdm/server.py
+++ b/mdm-server/styly_mdm/server.py
@@ -2968,6 +2968,25 @@ DISCOVERY_PORT = int(os.environ.get("MDM_DISCOVERY_PORT", "7071"))
 DISCOVERY_REQUEST = b"STYLYMDM_DISCOVER"
 
 
+def source_ip_for(peer: str) -> str | None:
+    """Return the local IPv4 the kernel would use to reach ``peer``, or None.
+
+    A connected UDP socket sends nothing — ``connect()`` only consults the routing
+    table — so this is a cheap, side-effect-free way to ask "which of my interfaces
+    faces this device?". That question is the whole point: a machine with several
+    interfaces (Wi-Fi plus an unplugged Ethernet holding a self-assigned
+    169.254.x.x, or Windows ICS alongside an uplink NIC) has no single "own" IP,
+    and the right answer differs per requester.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect((peer, 9))
+            ip = s.getsockname()[0]
+    except OSError:
+        return None
+    return ip if ip and not ip.startswith("127.") else None
+
+
 class _UdpDiscoveryProtocol(asyncio.DatagramProtocol):
     """Responds to UDP broadcast discovery requests with the server's WebSocket URL."""
 
@@ -2980,7 +2999,12 @@ class _UdpDiscoveryProtocol(asyncio.DatagramProtocol):
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]):
         if data.strip() == DISCOVERY_REQUEST:
-            server_ip = self._ip_addresses[0] if self._ip_addresses else "0.0.0.0"
+            # Answer with the address on the interface facing *this* requester. The
+            # startup-time list is only a fallback: it is fixed at boot and cannot
+            # know which network a device broadcast from.
+            server_ip = source_ip_for(addr[0])
+            if server_ip is None:
+                server_ip = self._ip_addresses[0] if self._ip_addresses else "0.0.0.0"
             response = json.dumps({
                 "service": "stylymdm",
                 "ws_url": f"ws://{server_ip}:{self._ws_port}/ws/device",
@@ -3094,12 +3118,19 @@ def create_app() -> web.Application:
 
 
 def get_local_ip_addresses() -> list[str]:
-    """Return a list of non-loopback IPv4 addresses for this machine."""
+    """Return this machine's usable non-loopback IPv4 addresses.
+
+    Feeds the startup banner and the discovery responder's fallback. Link-local
+    (169.254.0.0/16) addresses are dropped: they are self-assigned to interfaces
+    that failed DHCP — an unplugged Ethernet port or a Thunderbolt bridge — so they
+    are never reachable from a device on the real LAN. Advertising one to a client
+    is strictly worse than advertising nothing.
+    """
     addresses: list[str] = []
     try:
         for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
             ip = info[4][0]
-            if not ip.startswith("127."):
+            if not ip.startswith("127.") and not ip.startswith("169.254."):
                 addresses.append(ip)
     except OSError:
         pass

--- a/mdm-server/tests/test_discovery_response.py
+++ b/mdm-server/tests/test_discovery_response.py
@@ -1,0 +1,121 @@
+"""Tests for the address the discovery responder advertises.
+
+A device can only reach the server over the interface it broadcast from, so the
+``ws_url`` in a discovery response has to name *that* interface's address. These
+cover the two halves of that: picking the source address per requester, and
+keeping self-assigned link-local addresses out of the fallback list.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from unittest.mock import patch
+
+from styly_mdm import server
+
+
+class _FakeTransport:
+    """Captures what the protocol sends instead of touching the network."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[bytes, tuple[str, int]]] = []
+
+    def sendto(self, data: bytes, addr: tuple[str, int]) -> None:
+        self.sent.append((data, addr))
+
+
+def _respond_to(peer: str, ip_addresses: list[str]) -> dict:
+    """Drive one discovery request from ``peer`` and return the decoded reply."""
+    proto = server._UdpDiscoveryProtocol(7070, ip_addresses)
+    transport = _FakeTransport()
+    proto.connection_made(transport)
+    proto.datagram_received(server.DISCOVERY_REQUEST, (peer, 34438))
+    assert len(transport.sent) == 1
+    payload, addr = transport.sent[0]
+    assert addr == (peer, 34438)
+    return json.loads(payload.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# source_ip_for
+# ---------------------------------------------------------------------------
+
+def test_source_ip_for_unreachable_peer_is_none_or_routable():
+    """Never returns loopback: a client cannot reach the server at 127.0.0.1."""
+    ip = server.source_ip_for("127.0.0.1")
+    assert ip is None
+
+    # An arbitrary public address either routes out a real interface or does not
+    # route at all; both are acceptable, a loopback answer is not.
+    ip = server.source_ip_for("203.0.113.1")
+    assert ip is None or not ip.startswith("127.")
+
+
+def test_source_ip_for_malformed_peer_returns_none():
+    assert server.source_ip_for("not-an-ip-at-all") is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery response address selection
+# ---------------------------------------------------------------------------
+
+def test_response_uses_interface_facing_the_requester():
+    """The ICS/multi-homed case: answer with the address on the client's network."""
+    with patch.object(server, "source_ip_for", return_value="192.168.137.1"):
+        reply = _respond_to("192.168.137.177", ["169.254.23.62", "10.0.0.5"])
+
+    assert reply["service"] == "stylymdm"
+    assert reply["ws_url"] == "ws://192.168.137.1:7070/ws/device"
+
+
+def test_response_falls_back_to_local_list_when_route_lookup_fails():
+    with patch.object(server, "source_ip_for", return_value=None):
+        reply = _respond_to("192.168.137.177", ["192.168.1.50"])
+
+    assert reply["ws_url"] == "ws://192.168.1.50:7070/ws/device"
+
+
+def test_response_falls_back_to_wildcard_without_any_address():
+    with patch.object(server, "source_ip_for", return_value=None):
+        reply = _respond_to("192.168.137.177", [])
+
+    assert reply["ws_url"] == "ws://0.0.0.0:7070/ws/device"
+
+
+def test_non_discovery_datagram_is_ignored():
+    proto = server._UdpDiscoveryProtocol(7070, ["192.168.1.50"])
+    transport = _FakeTransport()
+    proto.connection_made(transport)
+    proto.datagram_received(b"something else", ("192.168.1.9", 5000))
+    assert transport.sent == []
+
+
+# ---------------------------------------------------------------------------
+# get_local_ip_addresses
+# ---------------------------------------------------------------------------
+
+def _addrinfo(*ips: str) -> list:
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+
+def test_local_addresses_drop_link_local_and_loopback():
+    """169.254.x.x is self-assigned to a dead interface — never advertise it."""
+    with patch.object(
+        server.socket, "getaddrinfo",
+        return_value=_addrinfo("127.0.0.1", "169.254.23.62", "192.168.137.1"),
+    ):
+        assert server.get_local_ip_addresses() == ["192.168.137.1"]
+
+
+def test_local_addresses_deduplicate_preserving_order():
+    with patch.object(
+        server.socket, "getaddrinfo",
+        return_value=_addrinfo("10.0.0.5", "192.168.1.50", "10.0.0.5"),
+    ):
+        assert server.get_local_ip_addresses() == ["10.0.0.5", "192.168.1.50"]
+
+
+def test_local_addresses_survive_resolution_failure():
+    with patch.object(server.socket, "getaddrinfo", side_effect=OSError("no dns")):
+        assert server.get_local_ip_addresses() == []


### PR DESCRIPTION
## Problem

Devices discovered the server but could never connect to it. The server was answering
discovery broadcasts with a link-local address the requester has no route to:

```
[INFO] Discovery request from 192.168.137.177:34438 -> responded with ws://169.254.23.62:7070
[INFO] Discovery request from 192.168.137.238:60755 -> responded with ws://169.254.23.62:7070
```

The responder used `get_local_ip_addresses()[0]` — the first address
`getaddrinfo(gethostname())` happened to return. That order is arbitrary, the value was
frozen at startup, and nothing filtered link-local addresses. Reproduced on the affected
machine with the old logic:

```
BEFORE (old logic) advertised: 169.254.23.62   full list: ['169.254.23.62', '192.168.137.91']
```

`169.254.23.62` was self-assigned to an inactive interface; the headsets were on
`192.168.137.x`.

## Why per-request, not just a filter

Dropping link-local addresses alone would still leave the server guessing from a fixed
list. A server machine rarely has one "own" IP — a laptop carries Wi-Fi plus an unplugged
Ethernet port, and a Windows host sharing its connection (ICS, `192.168.137.1`) carries
the shared network alongside its uplink NIC. The correct address depends on **which
network the requesting device broadcast from**, so it has to be resolved per request.

## Change

`source_ip_for()` opens a connected UDP socket toward the requester — `connect()` consults
the routing table and sends no packet — and reports the local address on the interface
facing them. `datagram_received` uses it and falls back to the startup list only if the
lookup fails. `get_local_ip_addresses()` now drops `169.254.0.0/16` alongside loopback, so
the fallback and the startup banner can no longer name an unreachable address.

## Verification

Measured on the affected machine after the change:

```
getaddrinfo list : ['192.168.137.91']     # link-local gone
192.168.137.177  -> 192.168.137.91        # correct address for the headset
127.0.0.1        -> None                  # never advertises loopback
garbage          -> None
```

New `tests/test_discovery_response.py` covers per-requester selection, both fallback paths,
and link-local/loopback filtering — the response side previously had no tests. Full suite:
244 passed.

Clients recover on their own. `WebSocketManager.startAutoDiscoveryAttempt()` runs discovery
first on every attempt cycle and unconditionally overwrites the cache via
`saveDiscoveredServerUrl()`; the cached URL is only used when discovery fails. Devices
holding `ws://169.254.23.62:7070` pick up the correct URL on their next cycle with no
device-side action.

`docs/DEVELOPMENT.md` gains a "Which address the server advertises" section.

## Not covered here

Verified on macOS only. The ICS case should be confirmed on the Windows host:

```
PYTHONPATH=. python -c "from styly_mdm import server; print(server.source_ip_for('192.168.137.177'))"
```

This is server-only, so it needs a PATCH version bump plus a reinstall before the fix can
be confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
